### PR TITLE
docs(tidy): make SAFE an allowlist and add never-delete denylist for secrets/venvs

### DIFF
--- a/commands/repo/tidy.md
+++ b/commands/repo/tidy.md
@@ -56,13 +56,53 @@ Also look for junk by pattern, wherever it lives:
 
 ### 2. Categorize
 
-- **SAFE** — regenerable with certainty: gitignored build output and caches,
-  OS/editor droppings, `__pycache__`, empty directories. Nothing in this
-  category may be tracked by git or match a source-code extension.
-- **ASK** — probably junk but needs a human call: untracked files that aren't
-  gitignored (could be unsaved work!), large files, stale-looking logs, old
-  `tmp/` contents. Stale worktrees, branches, and stashes are [[reset]]'s
-  job — point there instead of handling them here.
+**Gitignored ≠ safe to delete.** `git clean -ndX` lists *every* gitignored file
+on disk — including secrets (`.env`) and expensive-to-rebuild trees (`.venv/`),
+which are gitignored *precisely because* they're precious and local. Do not
+treat "gitignored" as a synonym for "regenerable." SAFE is an **allowlist** of
+recognized clutter; a **never-delete denylist** overrides it; everything else
+gitignored falls through to ASK.
+
+Apply these tests in order — **denylist first, then the SAFE allowlist, then
+fall through to ASK**:
+
+**Never-delete denylist (always ASK, never SAFE — checked first, overrides
+everything below, regardless of gitignore status):**
+- Secrets / credentials: `.env`, `.env.*` (but **not** `.env.example` /
+  `.env.sample`, which are templates safe to keep), `*.pem`, `*.key`,
+  `*.keystore`, `*.p12`, `*.pfx`, `id_rsa*`
+- Expensive-to-rebuild environments: `.venv/`, `venv/`, `env/`
+- Anything else that looks credential-like or holds unique local state
+  (local SQLite DBs, local-only config, sample-data caches)
+
+A denylist match routes to **ASK** (never auto-deleted) — not KEEP, which is
+reserved for tracked files.
+
+- **SAFE** — regenerable with certainty, matched by an explicit **allowlist** of
+  known build-output/cache/droppings patterns (never "everything `git clean
+  -ndX` lists minus a couple of exclusions"). A file is SAFE only if it does
+  **not** match the denylist above **and** matches one of:
+  - OS/editor droppings: `.DS_Store`, `Thumbs.db`, `*~`, `*.swp`, `.#*`
+  - Python caches: `__pycache__/`, `*.pyc`, `.pytest_cache/`, `.mypy_cache/`,
+    `.ruff_cache/`
+  - Build output: stale `dist/`, `.turbo/`, `.astro/`, `htmlcov/`, `.coverage`,
+    coverage output, `site/dist`
+  - Merge/patch leftovers: `*.orig`, `*.rej`, `*.BACKUP.*`
+  - Empty directories
+
+  Nothing in this category may be tracked by git or match a source-code
+  extension.
+- **ASK** — probably junk but needs a human call. This covers:
+  - Untracked files that aren't gitignored (could be unsaved work!), large
+    files, stale-looking logs, old `tmp/` contents.
+  - **Any gitignored file that matches the never-delete denylist** (secrets,
+    virtualenvs) — surfaced here, never auto-deleted.
+  - **Any gitignored file that does not match the SAFE allowlist** (a novel
+    cache dir, unrecognized local state) — when in doubt, it lands here, not in
+    SAFE.
+
+  Stale worktrees, branches, and stashes are [[reset]]'s job — point there
+  instead of handling them here.
 - **KEEP** — flagged only as information: tracked files that look like they
   don't belong (build output that got committed — point to [[gitignore]]).
 
@@ -78,6 +118,8 @@ SAFE (would free 412 MB):
   6 empty directories
 
 ASK:
+  .env                     gitignored, 1 KB  ← credentials, never auto-deleted
+  .venv/                   gitignored, 240 MB  ← virtualenv, expensive to rebuild
   notes-scratch.md         untracked, 3 KB, modified today  ← might be real work
   sim-output-old/          untracked, 1.2 GB, untouched 60 days
   worktree: ../repo-wt-fix123 (branch merged)
@@ -93,6 +135,12 @@ KEEP (informational):
 - With `--ask`: walk through every category with the user, including SAFE;
   delete only what they approve.
 
+The default auto-delete is scoped to **SAFE-allowlisted paths only**. Never pass
+a denylisted path (secrets, virtualenvs) or an unrecognized gitignored path to
+`git clean -fdX` — those are ASK items and require an explicit human call. Build
+the explicit `<paths>` list from the SAFE category and nothing else; do **not**
+run a blanket `git clean -fdX` that would sweep whatever `git clean -ndX` lists.
+
 Use `git clean -fdX -- <paths>` for gitignored artifacts and plain `rm` only
 for pattern-matched junk you listed in the report. After deleting, re-run the
 inventory to confirm and report bytes freed.
@@ -105,3 +153,7 @@ inventory to confirm and report bytes freed.
    unsaved work and always lands in ASK
 4. **Everything deleted must have appeared in the report first**
 5. When scoped to a subtree, do not delete anything outside it
+6. **Gitignored ≠ safe to delete** — the never-delete denylist (secrets like
+   `.env`/`*.pem`/`*.key`, and virtualenvs like `.venv/`/`venv/`) always
+   overrides SAFE and routes to ASK, regardless of what `git clean -ndX` lists.
+   Unrecognized gitignored files fall through to ASK, never SAFE.


### PR DESCRIPTION
## Summary

`/repo:tidy` inventoried deletion candidates with `git clean -ndX` (every gitignored file on disk) and defined the auto-deleted **SAFE** category as "gitignored build output and caches," gated only by two negative guards (not tracked, no source extension). Neither guard excludes `.env` (secrets) or `.venv/` (expensive to rebuild), so a faithful reading of the spec would sweep them into SAFE and `git clean -fdX` them. This reworks `commands/repo/tidy.md` so **gitignored ≠ safe to delete**.

## Changes

- **Step 2 (Categorize)**: SAFE is now an explicit **allowlist** of known build/cache/droppings patterns (`__pycache__/`, `*.pyc`, `.pytest_cache/`, `.mypy_cache/`, `.ruff_cache/`, `dist/`, `.turbo/`, `.astro/`, `htmlcov/`, `.coverage`, OS/editor droppings, merge/patch leftovers, empty dirs) — not "everything `git clean -ndX` lists minus exclusions."
- Added a **never-delete denylist**, checked first and overriding SAFE regardless of gitignore status: `.env`, `.env.*` (excluding `.env.example`/`.env.sample`), `*.pem`, `*.key`, `*.keystore`, `*.p12`, `*.pfx`, `id_rsa*`, and virtualenvs `.venv/`/`venv/`/`env/`. Denylist matches route to **ASK**, never KEEP.
- ASK now explicitly covers denylisted gitignored files **and** any gitignored file not on the SAFE allowlist (unrecognized → ASK).
- **Step 3 (Report)**: example now shows `.env` and `.venv/` under ASK with annotations.
- **Step 4 (Apply)**: default auto-delete is scoped to SAFE-allowlisted paths only; denylisted/unrecognized gitignored paths must never be passed to `git clean -fdX`.
- **Safety Rules**: added rule 6, "Gitignored ≠ safe to delete."

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| SAFE rewritten as an allowlist, not "everything `git clean -ndX` lists" | ✅ | Step 2 SAFE now enumerates explicit patterns; intro to step 2 states the allowlist principle |
| Denylist (.env/.env.*, *.pem, *.key, *.p12, *.pfx, id_rsa*, .venv/venv/env) documented and checked ahead of SAFE | ✅ | "Never-delete denylist" block precedes SAFE and is stated as checked first |
| Denylist + unrecognized gitignored classified ASK, never SAFE | ✅ | ASK definition explicitly folds in both cases; SAFE requires no denylist match AND allowlist match |
| Step 4 default scoped to SAFE-allowlist only; deny/unrecognized never passed to `git clean -fdX` | ✅ | Step 4 paragraph added stating exactly this |
| Step 3 report example includes a denylisted item under ASK | ✅ | `.env` and `.venv/` shown under ASK |
| KEEP semantics unchanged | ✅ | KEEP definition untouched (tracked files, informational) |
| Known SAFE patterns still SAFE (no regression) | ✅ | `__pycache__/`, `.mypy_cache/`, `.pytest_cache/`, `.ruff_cache/`, `dist/`, `.DS_Store`, empty dirs all listed in the SAFE allowlist |
| `.env.example`/`.env.sample` exclusion called out | ✅ | Denylist explicitly excludes them as safe-to-keep templates |

## Test Plan

`commands/repo/tidy.md` is a prose instruction file for an AI-agent skill; there is no executable test suite (repo `test`/`lint`/`check:ci` scripts are no-op placeholders). Verification is by reading the updated spec against the issue's acceptance criteria (table above). Manual walkthrough: a repo with `.gitignore` containing `.env`, plus `.venv/`, `__pycache__/`, and `dist/` on disk now classifies `.env` and `.venv/` as ASK while `__pycache__/` and `dist/` remain SAFE and auto-deletable.

Closes #2