### PR TITLE
fix(install): skip CLAUDE.md pointer when install destination is gitignored

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -153,7 +153,14 @@ if [[ "$DRY_RUN" == true ]]; then
   while IFS= read -r cmd; do
     echo "  $TARGET/.claude/commands/repo/$cmd.md"
   done <<<"$COMMANDS"
-  echo "  $TARGET/CLAUDE.md (marker-bounded REPO-SKILLS block)"
+  if [[ "$DEV" == true ]]; then
+    echo "  $TARGET/.gitignore (.claude/ entry; CLAUDE.md skipped in dev mode)"
+  elif git -C "$TARGET" check-ignore -q .claude/commands/repo 2>/dev/null \
+    || git -C "$TARGET" check-ignore -q .claude/skills/repo 2>/dev/null; then
+    echo "  $TARGET/CLAUDE.md (skipped — install destination is gitignored)"
+  else
+    echo "  $TARGET/CLAUDE.md (marker-bounded REPO-SKILLS block)"
+  fi
   exit 0
 fi
 
@@ -216,6 +223,28 @@ if [[ "$DEV" == true ]]; then
 fi
 
 CLAUDE_MD="$TARGET/CLAUDE.md"
+
+# If the install destination is gitignored in the target, the command/skill
+# files we just wrote are effectively machine-local (they won't be committed),
+# so a tracked CLAUDE.md pointer would advertise /repo:* commands whose files
+# aren't in the repo. Mirror dev mode here: skip the CLAUDE.md block entirely.
+# Probe each destination separately (check-ignore -q accepts only one pathname)
+# and skip if *either* is ignored, since a split state is itself broken. The
+# probe exits non-zero outside a git repo or when nothing is ignored, which
+# correctly falls through to the write path.
+dest_is_gitignored() {
+  git -C "$TARGET" check-ignore -q .claude/commands/repo 2>/dev/null \
+    || git -C "$TARGET" check-ignore -q .claude/skills/repo 2>/dev/null
+}
+if dest_is_gitignored; then
+  warning "Install destination (.claude/commands, .claude/skills) is gitignored in $TARGET;"
+  warning "skipping the CLAUDE.md pointer block (a committed pointer to uncommitted command"
+  warning "files is not what you want). The /repo:* commands still work in-session."
+  echo ""
+  success "Repo Skills v$VERSION installed. Try /repo:help in Claude Code."
+  exit 0
+fi
+
 # The block is intentionally lightweight: a pointer to the real docs, not an
 # inlined command dump. `/repo:help` and SKILL.md carry the authoritative,
 # always-current command list; duplicating it here just goes stale.


### PR DESCRIPTION
## Summary

The non-dev `install.sh` path appended a tracked `REPO-SKILLS` pointer block to `CLAUDE.md` unconditionally — even when the target repo gitignores `.claude/commands` / `.claude/skills` (as Loom-style repos do). The result was a committed pointer advertising `/repo:*` commands whose files are never tracked, forcing an awkward commit-or-not decision on every install. Dev mode already avoids this; this brings the non-dev path to parity.

## Changes

- `install.sh`: added a gitignore probe in the non-dev CLAUDE.md path, immediately after `CLAUDE_MD="$TARGET/CLAUDE.md"` and **before** any `$BLOCK_FILE` is created. If either destination (`.claude/commands/repo`, `.claude/skills/repo`) is gitignored in `$TARGET`, it prints a `warning()` notice, prints the final `success` line, and `exit 0` — mirroring dev mode and leaving `CLAUDE.md` untouched with no temp file leaked.
- Probe each destination separately and OR the results: `git check-ignore -q` rejects multiple pathnames (`--quiet is only valid with a single pathname`), so the curator's single two-arg invocation would have silently failed to 128 and never triggered. Skipping if *either* path is ignored also correctly covers the split-state edge case.
- Mirrored the skip in `--dry-run` output: shows `CLAUDE.md (skipped — install destination is gitignored)` for gitignored targets and a `.gitignore` line for dev mode, else the normal marker-block line.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Gitignored dest leaves CLAUDE.md byte-for-byte unchanged | done | S1: shasum before==after; `git status --short` shows no `M CLAUDE.md` |
| Clear skip notice printed | done | S1: prints "Install destination ... is gitignored ... skipping the CLAUDE.md pointer block ... /repo:* commands still work in-session" |
| Normal dest still appends/updates the block (no regression) | done | S2: `<!-- BEGIN REPO-SKILLS -->` appended; dest confirmed not gitignored |
| Re-install idempotency (block replaced, not duplicated) | done | S3: second run prints "Updated REPO-SKILLS block"; BEGIN marker count == 1 |
| Non-git target still writes the block (fail-safe) | done | S4: probe returns non-zero outside a git repo; block written |
| No temp `$BLOCK_FILE` left behind on skip | done | Guard exits before `mktemp` is called; tmp-dir count unchanged before/after |
| `--dev` unchanged (skips CLAUDE.md, gitignores `.claude/`) | done | S5: CLAUDE.md shasum unchanged; `.claude/` added to `.gitignore` |
| Only-one-of-two destinations ignored still skips | done | S6: `.gitignore` with only `.claude/commands`; CLAUDE.md unchanged |
| `--dry-run` reflects the skip | done | S7: gitignored dry-run shows "skipped"; normal dry-run shows the marker block |

## Test Plan

Ran `./install.sh -y <target>` against seven scratch repos under a temp dir (git repos created on the fly): gitignored (both dests), normal, re-install of normal, non-git dir, `--dev`, split-state (one dest ignored), and `--dry-run` for gitignored vs normal. All seven scenarios passed. `bash -n install.sh` clean.

Closes #4