### PR TITLE
docs(release): make Phase 1.5 CHANGELOG gate accept bracket-less headers

### DIFF
--- a/commands/repo/release.md
+++ b/commands/repo/release.md
@@ -46,9 +46,29 @@ CHANGELOG entry — cheap to catch now, expensive to reconstruct later. **No-op 
 `CHANGELOG.md` is absent** (Phase 4 bootstraps it).
 
 ```bash
-[ -f CHANGELOG.md ] || echo "(no CHANGELOG.md — skipping gate)"
-# For each of the last ~5 tags (git tag --sort=-v:refname), check that
-# CHANGELOG.md contains a header for its version (strip a leading 'v').
+if [ ! -f CHANGELOG.md ]; then
+  echo "(no CHANGELOG.md — skipping gate)"
+else
+  # For each of the last ~5 tags, check CHANGELOG.md has a header for its
+  # version. The accepted header shape is format-AGNOSTIC: this repo uses the
+  # bracket-LESS "## 0.4.1 (2026-07-16)" form, but Keep-a-Changelog
+  # "## [0.4.1] - 2026-07-16" is equally valid. Accept BOTH — with an optional
+  # leading 'v' and optional surrounding brackets — and match the version's
+  # dots LITERALLY (escape them) so "0.4.1" cannot spuriously match "0X4X1" or
+  # "0.4.10". This mirrors the optional-bracket extraction Phase 6 uses
+  # (sed "/^## \[\?$NEW/…") and additionally tolerates a leading 'v' on the
+  # header, so the read side (this gate) and the write side (Phase 4 draft /
+  # Phase 6 extract) never disagree about what a version header looks like.
+  for tag in $(git tag --sort=-v:refname | head -5); do
+    ver="${tag#v}"                                     # strip a leading 'v'
+    ver_re="$(printf '%s' "$ver" | sed 's/\./\\./g')"  # escape dots -> literal
+    if grep -Eq "^##[[:space:]]+v?\[?${ver_re}\]?([[:space:]]|\$)" CHANGELOG.md; then
+      echo "ok: $ver"
+    else
+      echo "MISSING: $ver"
+    fi
+  done
+fi
 ```
 
 For any tag missing an entry, surface the gap and offer: **[b]** backfill it now


### PR DESCRIPTION
## Summary

Phase 1.5's CHANGELOG completeness gate said only that `CHANGELOG.md` "contains a header for its version", which led implementers to grep the Keep-a-Changelog bracketed form (`## [x.y.z]`). That false-negatives on this repo's actual bracket-less headers (`## 0.4.1 (2026-07-16)`), reporting recent tags as MISSING when their entries exist. This replaces the ambiguous prose with a concrete, format-agnostic check.

## Changes

- Rewrote the Phase 1.5 version-header check (`commands/repo/release.md`) as a runnable, format-agnostic snippet:
  - Accepts BOTH `## [x.y.z]` and `## x.y.z`, with optional surrounding brackets and an optional leading `v`.
  - Escapes the version's dots so they match literally (`sed 's/\./\\./g'`) — `0.4.1` cannot match `0X4X1` or `0.4.10`.
  - Anchors on `^##[[:space:]]+v?\[?<ver>\]?([[:space:]]|$)` with a trailing boundary to prevent prefix false-positives.
  - Strips a leading `v` from the tag before matching, so `v0.4.1` and `0.4.1` reconcile in both directions.
- Documented that this mirrors Phase 6's optional-bracket extraction (`sed "/^## \[\?$NEW/…"`) and additionally tolerates a leading `v`, keeping the read side consistent with the Phase 4 draft / Phase 6 extract write side. No Keep-a-Changelog bracket assumption is introduced anywhere; `CHANGELOG.md` is not modified.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| 1. Bracket-less CHANGELOG no longer false-negatives | ✅ | `## 0.4.1 (2026-07-16)` / `## 0.4.0 (…)` → reports `ok`, zero MISSING (tested; matches this repo's real CHANGELOG headers) |
| 2. Bracketed (Keep-a-Changelog) still works | ✅ | `## [0.4.1] - 2026-07-16` → reports `ok` (no regression) |
| 3. Genuinely missing entry still reported | ✅ | tag `0.9.9` with no header → `MISSING`; the [b]/[c]/[a] choices below the snippet are unchanged |
| 4. Leading `v` tolerated both ways | ✅ | tag `v0.4.1` vs header `0.4.1` → ok; tag `0.4.1` vs header `v0.4.1` → ok |
| 5. Version dots matched literally | ✅ | `0.4.1` does NOT match header `0X4X1` (dots escaped) |
| 6. No cross-phase contradiction | ✅ | Accepted shape (optional bracket + optional `v`) aligns with Phase 4 draft and Phase 6 extraction; comment documents the alignment |

Additional guard: `0.4.1` does not partial-match `0.4.10` (trailing boundary tested).

## Test Plan

Prose/command-doc change — verified by careful reading plus extracting the fenced snippet and running it against synthetic CHANGELOGs:

- `bash -n` on the extracted snippet: clean.
- Ran the match logic against bracket-less, bracketed, leading-`v`, missing, `0X4X1`, and `0.4.10` cases — all behaved as required (see criteria table).
- Confirmed only `commands/repo/release.md` changed; `CHANGELOG.md` untouched.

Closes #7