### PR TITLE
fix: move machine-local source path + timestamp out of tracked install metadata

### DIFF
--- a/commands/repo/help.md
+++ b/commands/repo/help.md
@@ -26,11 +26,20 @@ commands.
 ```bash
 ls .claude/commands/repo/*.md
 cat .claude/skills/repo/install-metadata.json
+cat .claude/skills/repo/.install-local.json 2>/dev/null   # machine-local, gitignored
 ```
 
 Build the command list from the files present. For each, pull the one-line
 `description:` from its frontmatter. Do not list commands that are not
 installed here.
+
+`install-metadata.json` (tracked) carries `version`, `commands`, and `dev`. The
+install date lives in the gitignored `.install-local.json` sidecar
+(`installed_at`), so it is present only on the machine that ran the install;
+older installs still keep `installed_at` inline in `install-metadata.json`. Use
+whichever is present for the date below, and simply omit "(installed <date>)"
+when neither has it (e.g. a fresh clone on another machine) — its absence is
+expected, not an error.
 
 ### 2. Present the overview
 

--- a/commands/repo/update-tools.md
+++ b/commands/repo/update-tools.md
@@ -38,8 +38,28 @@ ls .claude/skills/*/install-metadata.json 2>/dev/null
 
 Key names vary by tool (`version` vs `loom_version` / `anvil_version`, `source`
 vs `loom_source` / `anvil_source`) — read whichever variant is present. Each
-file gives: installed version, installed commit, install date, and the path of
-the local source clone it was installed from.
+file gives: installed version, installed commit, install date, and (for the
+"prefer local source clone" fast path) the path of the local source clone it
+was installed from.
+
+**Locating the local source path (`source`).** The absolute source path and
+install timestamp are machine-local — they mean nothing in another clone — so
+newer installers keep them out of the tracked metadata file and write them to a
+gitignored sidecar instead. Resolve `source` in this order, and treat every
+step failing as "source clone unknown" rather than an error:
+
+1. **Sidecar first.** For Repo Skills, read
+   `.claude/skills/repo/.install-local.json` (generally
+   `.claude/skills/*/.install-local.json`); it holds `source` and
+   `installed_at`. Loom uses the plain-text `.loom/loom-source-path` sidecar for
+   the same purpose. A sidecar is gitignored, so it is present only on the
+   machine that ran the install — a fresh clone elsewhere legitimately has none.
+2. **Legacy inline fallback.** Older (pre-split) installs still embed `source` /
+   `installed_at` directly in `install-metadata.json` — read them from there if
+   no sidecar exists, so existing installs keep their fast path.
+3. **Unknown → GitHub.** If neither yields a usable path, the local source clone
+   is simply unknown; skip to the GitHub check in step 2. This is normal (fresh
+   clone on a different machine), not a failure.
 
 Known family members: Loom (`.loom/`), Anvil (`.anvil/`), Repo Skills
 (`.claude/skills/repo/`), kicad-tools, and anything else that follows the same

--- a/install.sh
+++ b/install.sh
@@ -150,6 +150,7 @@ if [[ "$DRY_RUN" == true ]]; then
   echo "Would write:"
   echo "  $TARGET/.claude/skills/repo/SKILL.md"
   echo "  $TARGET/.claude/skills/repo/install-metadata.json"
+  echo "  $TARGET/.claude/skills/repo/.install-local.json (machine-local, gitignored)"
   while IFS= read -r cmd; do
     echo "  $TARGET/.claude/commands/repo/$cmd.md"
   done <<<"$COMMANDS"
@@ -159,6 +160,7 @@ if [[ "$DRY_RUN" == true ]]; then
     || git -C "$TARGET" check-ignore -q .claude/skills/repo 2>/dev/null; then
     echo "  $TARGET/CLAUDE.md (skipped — install destination is gitignored)"
   else
+    echo "  $TARGET/.gitignore (.claude/skills/repo/.install-local.json entry)"
     echo "  $TARGET/CLAUDE.md (marker-bounded REPO-SKILLS block)"
   fi
   exit 0
@@ -195,17 +197,48 @@ done <<<"$COMMANDS"
 success "Installed $(echo "$COMMANDS" | wc -l | tr -d ' ') commands into .claude/commands/repo/"
 
 # 3. Install metadata
+# Tracked file: only fields that are identical for any machine installing the
+# same version/commit/skill-set, so repeat installs of a release are byte-
+# reproducible and no machine-local path/timestamp leaks into consumer history.
 {
   echo "{"
   echo "  \"version\": \"$VERSION\","
   echo "  \"commit\": \"$COMMIT\","
-  echo "  \"installed_at\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\","
   echo "  \"dev\": $DEV,"
-  echo "  \"source\": \"$SOURCE_ROOT\","
   echo "  \"commands\": [$(echo "$COMMANDS" | sed 's/.*/"&"/' | paste -sd, -)]"
   echo "}"
 } >"$TARGET/.claude/skills/repo/install-metadata.json"
 success "Wrote install-metadata.json"
+
+# Machine-local sidecar (gitignored): the absolute source-clone path and the
+# run-specific install timestamp. These are meaningless in any other clone and
+# must never be committed. /repo:update-tools reads `source` from here to prefer
+# the local source clone; this mirrors the existing .loom/loom-source-path
+# precedent for the identical Loom-self-install problem.
+{
+  echo "{"
+  echo "  \"source\": \"$SOURCE_ROOT\","
+  echo "  \"installed_at\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\""
+  echo "}"
+} >"$TARGET/.claude/skills/repo/.install-local.json"
+success "Wrote .install-local.json (machine-local, gitignored)"
+
+# Ensure the sidecar is gitignored on every install. Dev mode ignores the whole
+# .claude/ tree in step 4 below (which already covers the sidecar), so only the
+# copy install needs an explicit entry here. Guard with check-ignore so we skip
+# when the path is already ignored (e.g. destination-gitignored installs), and
+# grep so a re-install never appends a duplicate line.
+if [[ "$DEV" != true ]] \
+  && ! git -C "$TARGET" check-ignore -q .claude/skills/repo/.install-local.json 2>/dev/null; then
+  GITIGNORE="$TARGET/.gitignore"
+  SIDECAR_IGNORE=".claude/skills/repo/.install-local.json"
+  if [[ ! -f "$GITIGNORE" ]] || ! grep -qxF "$SIDECAR_IGNORE" "$GITIGNORE"; then
+    { [[ -f "$GITIGNORE" && -s "$GITIGNORE" ]] && echo ""
+      echo "# Repo Skills machine-local install metadata (absolute source path + timestamp)"
+      echo "$SIDECAR_IGNORE"; } >>"$GITIGNORE"
+    success "Added $SIDECAR_IGNORE to .gitignore"
+  fi
+fi
 
 # 4. CLAUDE.md block (replace existing block in place, else append).
 # Skipped in dev mode: the symlinked install is machine-local (absolute symlinks


### PR DESCRIPTION
## Summary

`install.sh` wrote an absolute `source` path (the installer's checkout on the installing machine) and a run-specific `installed_at` timestamp into the **tracked** `.claude/skills/repo/install-metadata.json`. Because that file lands in the consumer's tracked `.claude/` tree, it got committed — leaking a machine-local path into shared history and making two installs of the same version+commit+skill-set produce different tracked bytes.

`source` is not decorative: `/repo:update-tools` reads it to prefer the local source clone over the GitHub API. So it is split out rather than dropped, following the existing `.loom/loom-source-path` gitignored-sidecar precedent already used for the identical Loom-self-install problem.

## Changes

- **`install.sh`**: tracked `install-metadata.json` now contains only `version`, `commit`, `dev`, `commands`. `source` + `installed_at` move to a new gitignored sidecar `.claude/skills/repo/.install-local.json`. The installer adds that path to the target `.gitignore` on every (not just dev-mode) install — idempotently, and only when not already covered by a broader ignore (`git check-ignore` guard). `--dry-run` lists the sidecar and its gitignore entry.
- **`commands/repo/update-tools.md`**: discovery step now resolves `source` from the sidecar first, falls back to legacy inline `source` in `install-metadata.json` for pre-fix installs, then to "unknown → GitHub" — none treated as an error.
- **`commands/repo/help.md`**: reads the install date from the sidecar (or legacy inline) and omits `(installed <date>)` gracefully when neither is present. (The curator's AC assumed help.md did not use the date; the doc's overview template does, so it is handled here.)

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Non-dev tracked metadata has no `source`/`installed_at` | ✅ | Installed into fresh repo; tracked file = version/commit/dev/commands only |
| Sidecar holds `source`/`installed_at`, gitignored | ✅ | Sidecar written; absent from `git status --short` after `git add -A` |
| `.gitignore` gets sidecar entry on every install | ✅ | Entry added in non-dev; dev-mode `.claude/` wholesale ignore covers it |
| `--dry-run` reflects sidecar + gitignore | ✅ | Dry-run lists `.install-local.json` and the gitignore entry |
| Two installs from differently-named checkouts → byte-identical tracked metadata | ✅ | `diff` of the two tracked files: identical |
| `update-tools.md` sidecar → legacy → GitHub fallback, none an error | ✅ | Discovery step rewritten with explicit 3-step chain |
| `help.md` unbroken by the split | ✅ | Reads version/commands/dev from tracked file; date from sidecar/legacy, omitted if absent |
| No dev-mode regression | ✅ | `--dev` still exits early, `.claude/` gitignored wholesale; sidecar covered, no duplicate entry; metadata + sidecar remain real files (not symlinks) |

## Test Plan

Ran locally against fresh `git init` targets:
1. Non-dev install → tracked metadata clean, sidecar gitignored (not in `git status`).
2. Byte-identical tracked metadata across two differently-named source checkouts at the same commit.
3. `--dry-run` lists sidecar + gitignore entry.
4. Idempotent re-install → no duplicate `.gitignore` line.
5. `--dev` install → `.claude/` wholesale ignore, sidecar covered, real files, no redundant entry.
6. Destination-already-gitignored install → no redundant sidecar line (check-ignore guard).

Closes #14