### PR TITLE
docs(help): add /repo:release to the command table

### DIFF
--- a/commands/repo/help.md
+++ b/commands/repo/help.md
@@ -59,6 +59,7 @@ stashes, untracked files) always need an explicit opt-in.
 | /repo:reset | Done with a task — get back on main, synced, stale state reviewed |
 | /repo:tidy  | Working tree cluttered with build artifacts and temp files |
 | /repo:remote | Need a cloud dev box (GCP/AWS) with this repo ready to go |
+| /repo:release | Cut a release — pre-flight, semver, CHANGELOG, version bump, tag, GitHub Release |
 
 ### Periodic maintenance
 | /repo:audit | Monthly sweep, or after a big refactor/import |


### PR DESCRIPTION
## What

Adds the missing `/repo:release` row to the Everyday table in `/repo:help`.

## Why

`/repo:release` shipped in v0.3.0 (the takeover of the deprecated `loom:release`) and is registered in `skills/repo/SKILL.md`, but the `/repo:help` command table never listed it — so the command was undiscoverable via help. This closes that gap.

One line, docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)