### PR TITLE
docs(update-tools): commit + land tool updates on the default branch by default

### DIFF
--- a/commands/repo/update-tools.md
+++ b/commands/repo/update-tools.md
@@ -15,15 +15,22 @@ to update the stale ones.
 ## Usage
 
 ```
-/repo:update-tools             # Report, then offer updates
-/repo:update-tools --check     # Report only
-/repo:update-tools loom        # Only check/update one tool
+/repo:update-tools               # Report, then offer updates (commit + land on the default branch)
+/repo:update-tools --check       # Report only, never writes
+/repo:update-tools loom          # Only check/update one tool
+/repo:update-tools --no-commit   # Update the working tree but leave it uncommitted for review
 ```
 
 An update runs the tool's own installer (executing code from its source repo
 and rewriting `.claude/`), so unlike the safe-fix hygiene commands this one is
 **not** auto-applied — it reports and confirms before updating. `--check` is
 the report-only form.
+
+Once an update is confirmed, it is committed and landed on the default branch
+(`main`) by default — it does **not** push, and it never folds a pre-existing
+dirty working tree into the update commit. Pass `--no-commit` (alias
+`--stage-only`) to restore the old behavior of leaving the changes uncommitted
+for manual review. See step 5 and the Safety Rules for details.
 
 ## Steps
 
@@ -114,9 +121,66 @@ git -C <source> pull --ff-only
 If the source clone has local modifications or `--ff-only` fails, report it
 and skip that tool rather than resolving on your own.
 
-After updating, re-read each metadata file to confirm the new version, and
-show a summary of what changed in the repo (`git status --short`) so the user
-can review and commit the update.
+After updating, re-read each metadata file to confirm the new version and show
+a summary of what changed (`git status --short`).
+
+### 5. Land the update (default)
+
+A confirmed tool bump is a safe, reversible, version-controlled change (the
+installer is idempotent and re-runnable), so by default `update-tools` **commits
+it and lands it on the default branch** rather than stopping at an uncommitted
+diff. It **never** pushes — pushing is outward-facing and stays a separate,
+explicit action (Safety Rule 5). Pass `--no-commit` (alias `--stage-only`) to
+skip this step and leave the working-tree changes uncommitted for manual review
+instead (the old behavior).
+
+Land each tool's bump as its own commit:
+
+1. **Isolate the installer's footprint.** Snapshot the working tree *before*
+   running the installer so a pre-existing dirty tree is never folded into the
+   update commit:
+
+   ```bash
+   pre=$(mktemp); post=$(mktemp)
+   git -C <this-repo> status --porcelain | sed 's/^...//' | sort > "$pre"
+   # ... run the tool's installer (step 4, above) ...
+   git -C <this-repo> status --porcelain | sed 's/^...//' | sort > "$post"
+   # Paths the installer actually changed = post minus pre:
+   comm -13 "$pre" "$post" > changed.txt
+   ```
+
+   Stage **only** those paths (`git -C <this-repo> add -- $(cat changed.txt)`),
+   never `git add -A`. If `changed.txt` is empty the installer was a no-op —
+   report "already current" and skip the commit for that tool.
+
+2. **Commit + land on the default branch, without committing straight to it:**
+
+   ```bash
+   DEFAULT=$(git -C <this-repo> symbolic-ref --quiet --short refs/remotes/origin/HEAD | sed 's#^origin/##')
+   DEFAULT=${DEFAULT:-main}
+   CUR=$(git -C <this-repo> symbolic-ref --short HEAD)
+   MSG="chore(tooling): update <tool> <old>→<new>"
+
+   if [ "$CUR" = "$DEFAULT" ]; then
+     # On the default branch: commit on a short-lived branch, then fast-forward
+     # merge it in — lands on the default branch without a straight-to-main commit.
+     tmp="tooling/update-<tool>-<new>"
+     git -C <this-repo> checkout -b "$tmp"
+     git -C <this-repo> commit -m "$MSG"
+     git -C <this-repo> checkout "$DEFAULT"
+     git -C <this-repo> merge --ff-only "$tmp"
+     git -C <this-repo> branch -d "$tmp"
+   else
+     # Already on a feature branch: commit here and report where it landed —
+     # do NOT switch branches mid-session and disturb the user's working state.
+     git -C <this-repo> commit -m "$MSG"
+     echo "Landed the update on '$CUR' (not '$DEFAULT') — you are on a feature branch."
+   fi
+   ```
+
+3. **Report** the resulting commit (`git -C <this-repo> log --oneline -1`) and
+   remind the user it has **not** been pushed (run `git push` explicitly to
+   share it).
 
 ## Safety Rules
 
@@ -125,5 +189,11 @@ can review and commit the update.
    marker blocks; hand-copying breaks reinstall idempotency
 3. **Never resolve source-repo git problems silently** (diverged clone, dirty
    tree) — report and skip
-4. **The update touches the working tree** — leave the changes uncommitted for
-   the user to review
+4. **Land the update, don't just stage it** — by default commit the installer's
+   changes and land them on the default branch with a per-tool
+   `chore(tooling): update <tool> <old>→<new>` message. Stage **only** the paths
+   the installer actually changed — never fold a pre-existing dirty working tree
+   into the update commit. `--no-commit` / `--stage-only` restores the old
+   leave-it-uncommitted-for-review behavior.
+5. **Never push** — landing on the local default branch is reversible; pushing is
+   outward-facing and stays a separate, explicit action the user runs themselves.


### PR DESCRIPTION
## Summary

`/repo:update-tools` previously ran each tool's installer and stopped, leaving
the changes uncommitted in the working tree for the human to branch/commit/merge
by hand. This changes the default so a **confirmed** update is committed and
landed on the default branch (`main`) automatically, matching the "safe,
reversible fixes applied by default" convention of the other `/repo:*` hygiene
commands. Pushing stays a separate, explicit action, and a `--no-commit` escape
hatch restores the old review-first behavior.

## Changes

- **Usage**: added the `--no-commit` flag and a note that confirmed updates are
  committed + landed on the default branch by default (never pushed).
- **New step 5 "Land the update (default)"**: after the existing confirmation
  gate (step 4), commit the installer's output and land it on the default branch:
  - Snapshots the working tree before/after the installer and stages **only** the
    paths the installer actually changed (`comm -13` of pre/post `git status`),
    so a pre-existing dirty tree is never folded into the update commit.
  - Commits per tool with a `chore(tooling): update <tool> <old>→<new>` message.
  - When on the default branch: commits on a short-lived branch and
    `git merge --ff-only`s it in (lands on `main` without a straight-to-main
    commit); when already on a feature branch: commits in place and reports where
    it landed rather than switching branches mid-session.
  - Reports the commit and reminds the user it has not been pushed.
- **Safety Rules**: rewrote Rule 4 (was "leave the changes uncommitted for the
  user to review") to describe the new commit-and-land default + `--no-commit`
  escape hatch, and added Rule 5 ("Never push").

Only `commands/repo/update-tools.md` is touched (its `.claude/…` counterpart is a
symlink to this source file). README's classification of `update-tools` as a
"confirm-first" command remains accurate and is unchanged.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| By default, after a confirmed update, commit the installer's changes and land them on `main` with a per-tool commit message | ✅ | Step 5 + Safety Rule 4; commit msg `chore(tooling): update <tool> <old>→<new>`; branch→commit→`--ff-only` merge to default (or in-place on a feature branch) |
| Default does not push without explicit opt-in | ✅ | Step 5 and Safety Rule 5 state it never pushes; no `git push` anywhere in the flow |
| A documented flag restores the "leave it uncommitted for review" behavior | ✅ | `--no-commit` (alias `--stage-only`) added to Usage, step 5, and Safety Rule 4 |
| Safety Rules updated; dirty pre-existing tree handled safely | ✅ | Rules 4–5 rewritten; step 1 of the landing sequence stages only the installer's own paths via pre/post snapshot diff, never `git add -A` |
| On a non-`main` branch behaves sensibly | ✅ | Branch check commits in place and reports the landing branch instead of switching branches mid-session |

## Test Plan

This command family is markdown agent-instruction files with no executable
harness for the command itself. Verified:
- Scope check: `git diff --stat` shows only `commands/repo/update-tools.md`.
- `npm run check:ci` passes; `npm test` (hook guard suite) passes 49/49 —
  confirms no unrelated breakage.
- Manual read-through of the new step 5 / Safety Rules against each acceptance
  criterion (table above).

Closes #25