### PR TITLE
feat(hooks): surface a pending /repo:handoff note via a SessionStart hook

### DIFF
--- a/hooks/repo/session-start-handoff.sh
+++ b/hooks/repo/session-start-handoff.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# session-start-handoff.sh - SessionStart hook that surfaces a pending
+# /repo:handoff note at the start of a Claude Code session.
+#
+# Part of Repo Skills (https://github.com/rjwalters/repo), installed by
+# install.sh into .claude/skills/repo/hooks/ and wired into the consumer repo's
+# .claude/settings.json under hooks.SessionStart (matchers "startup" and
+# "resume").
+#
+# WHY: /repo:handoff writes .claude/handoff.md and adds a pointer line to the
+# agent's memory index. That makes the note findable, but nothing announces it,
+# and the command's one-shot contract ("read it, then delete it") means a note
+# that never gets absorbed lingers silently. handoff.md calls a stale note "a
+# trap of its own". This hook makes both facts visible at session start.
+#
+# =============================================================================
+# STABLE INTERFACE (the contract install.sh/uninstall.sh and the tests rely on)
+# =============================================================================
+#
+# Input:  JSON on stdin (Claude Code SessionStart payload). Fields consumed:
+#           .cwd    - the session's working directory
+#           .source - "startup" | "resume" | "clear" | "compact" | "fork"
+#         Anything else in the payload is ignored.
+#
+# Output: silence + exit 0  => nothing to surface;  otherwise EXACTLY one JSON
+#         object on stdout:
+#           { "hookSpecificOutput": { "hookEventName": "SessionStart",
+#               "additionalContext": "..." } }
+#         The "hookEventName" field is REQUIRED by Claude Code's schema -
+#         without it the additionalContext is silently discarded.
+#
+# Exit:   ALWAYS 0, on every path including internal error. SessionStart has no
+#         decision control (a hook cannot block session start), so the only
+#         thing a failure here can accomplish is noise in the transcript.
+#
+# Errors: this script MUST never exit non-zero and never emit invalid output.
+#         Any internal error is caught by the ERR trap, logged to
+#         <script-dir>/../logs/hook-errors.log, and resolves to silence (fail
+#         open) - mirroring guard-destructive.sh's convention.
+#
+# READ-ONLY: this hook never writes, deletes, or modifies .claude/handoff.md or
+#         any other file in the repo. Deleting the note after it is absorbed is
+#         the /repo:handoff one-shot contract's job, not this hook's. The only
+#         file it may ever write is its own diagnostic error log.
+#
+# SOURCE GATING: only "startup" and "resume" are acted on. install.sh wires
+#         exactly those two matchers, and this script re-checks .source anyway
+#         so a hand-edited settings.json that routes "clear"/"compact"/"fork"
+#         here still no-ops. A /clear is not a process relaunch and the note has
+#         not been touched, so repeating the banner there is pure noise.
+# =============================================================================
+
+# Age thresholds (hours). STALE_HOURS is the ">7d" line handoff.md warns about.
+RECENT_HOURS=48
+STALE_HOURS=168
+
+# Max section headers rendered. The real-world note that motivated this was
+# 7.5 KB - far too much to inject on every launch - but its headers convey the
+# shape in a handful of lines.
+MAX_HEADERS=9
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd 2>/dev/null || echo ".")"
+HOOK_ERROR_LOG="${SCRIPT_DIR}/../logs/hook-errors.log"
+
+# Log a diagnostic error message (best-effort, never fails the script).
+log_hook_error() {
+    local msg="$1"
+    mkdir -p "$(dirname "$HOOK_ERROR_LOG")" 2>/dev/null || true
+    echo "[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] [session-start-handoff] $msg" >> "$HOOK_ERROR_LOG" 2>/dev/null || true
+}
+
+# Top-level error trap: on ANY unexpected error, emit nothing and exit 0. Note
+# this exits BEFORE any stdout is produced (the single printf below is the last
+# statement in the script), so the trap can never truncate a half-written JSON
+# object into malformed output.
+trap 'log_hook_error "Unexpected error on line ${LINENO}: ${BASH_COMMAND:-unknown} (exit=$?)"; exit 0' ERR
+
+# Read stdin safely - if cat fails, the ERR trap fires and we stay silent.
+INPUT=$(cat 2>/dev/null) || INPUT=""
+
+# jq is how we both parse the payload and build well-formed output. Without it
+# we cannot guarantee valid JSON, so stay silent rather than hand-roll one.
+if ! command -v jq &>/dev/null; then
+    log_hook_error "jq not found in PATH - emitting no context"
+    exit 0
+fi
+
+SOURCE=$(printf '%s' "$INPUT" | jq -r '.source // empty' 2>/dev/null) || SOURCE=""
+CWD=$(printf '%s' "$INPUT" | jq -r '.cwd // empty' 2>/dev/null) || CWD=""
+
+# Source gating. An absent/unparseable source means malformed input, which
+# fails open to silence rather than guessing.
+case "$SOURCE" in
+    startup|resume) ;;
+    *) exit 0 ;;
+esac
+
+# Resolve the repo root from cwd (handles worktrees). Fall back to cwd itself
+# when it is not a git repo, mirroring the original proposal's
+# `root=$(git rev-parse --show-toplevel) || root=$PWD`.
+[[ -n "$CWD" && -d "$CWD" ]] || exit 0
+REPO_ROOT=$(git -C "$CWD" rev-parse --show-toplevel 2>/dev/null) || REPO_ROOT=""
+[[ -n "$REPO_ROOT" ]] || REPO_ROOT="$CWD"
+
+NOTE="$REPO_ROOT/.claude/handoff.md"
+[[ -f "$NOTE" && -r "$NOTE" ]] || exit 0
+
+# Portable mtime: BSD/macOS `stat -f %m` vs GNU `stat -c %Y`. If neither works
+# we cannot compute age, so skip the banner entirely rather than emit a partial
+# one or error out.
+MTIME=$(stat -f %m "$NOTE" 2>/dev/null) || MTIME=""
+[[ -n "$MTIME" ]] || MTIME=$(stat -c %Y "$NOTE" 2>/dev/null) || MTIME=""
+[[ "$MTIME" =~ ^[0-9]+$ ]] || { log_hook_error "could not stat mtime of $NOTE - emitting no context"; exit 0; }
+
+NOW=$(date +%s 2>/dev/null) || NOW=""
+[[ "$NOW" =~ ^[0-9]+$ ]] || exit 0
+
+AGE_H=$(( (NOW - MTIME) / 3600 ))
+# Clock skew / a future mtime would otherwise produce a negative age. Written as
+# an `if` rather than `(( )) &&` so the arithmetic test's non-zero status in the
+# common case can never reach the ERR trap.
+if (( AGE_H < 0 )); then AGE_H=0; fi
+
+if   (( AGE_H < 1 ));             then AGE_LABEL="just now"
+elif (( AGE_H < RECENT_HOURS ));  then AGE_LABEL="${AGE_H}h old"
+else                                   AGE_LABEL="$(( AGE_H / 24 ))d old"
+fi
+
+# Headers only - never the file body. `|| true` because grep exits 1 when the
+# note has no headers at all (a valid, non-error state) and head closing the
+# pipe early can surface as a non-zero status.
+HEADERS=$(grep -E '^#{1,2} ' "$NOTE" 2>/dev/null | head -n "$MAX_HEADERS" | sed 's/^#* *//' || true)
+
+CONTEXT="A /repo:handoff note is pending in this repository.
+
+  Path: $NOTE
+  Age:  $AGE_LABEL"
+
+if (( AGE_H >= STALE_HOURS )); then
+    CONTEXT="$CONTEXT
+  STALE: this note is older than 7 days. A handoff describes one moment; verify
+         every claim in it against the repo before acting on it."
+fi
+
+if [[ -n "$HEADERS" ]]; then
+    CONTEXT="$CONTEXT
+
+Sections:
+$(printf '%s\n' "$HEADERS" | sed 's/^/  - /')"
+fi
+
+CONTEXT="$CONTEXT
+
+Read the note in full before doing anything else. Per the /repo:handoff one-shot
+contract, once you have absorbed it, delete both the note and its pointer line
+in the memory index - promote anything durable into real memory files or issues."
+
+OUTPUT=$(jq -cn --arg ctx "$CONTEXT" \
+    '{hookSpecificOutput: {hookEventName: "SessionStart", additionalContext: $ctx}}' 2>/dev/null) || OUTPUT=""
+
+# Never emit anything if jq could not build well-formed JSON.
+[[ -n "$OUTPUT" ]] || { log_hook_error "jq failed to build output JSON - emitting no context"; exit 0; }
+
+printf '%s\n' "$OUTPUT"
+exit 0

--- a/hooks/repo/tests/run.sh
+++ b/hooks/repo/tests/run.sh
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
-# Test harness for guard-destructive.sh.
+# Test harness for the Repo Skills hooks — the entry point `pnpm test` runs.
 #
 # Pure bash — no external test framework required (Repo Skills ships no test
-# runner, and bats is not assumed to be installed). Each case pipes a Claude
-# Code PreToolUse JSON payload ({"tool_input":{"command":...},"cwd":...}) to the
-# hook and asserts the resulting permissionDecision (deny / ask / allow).
+# runner, and bats is not assumed to be installed). Each guard case pipes a
+# Claude Code PreToolUse JSON payload ({"tool_input":{"command":...},"cwd":...})
+# to guard-destructive.sh and asserts the resulting permissionDecision
+# (deny / ask / allow). The SessionStart handoff hook's suite is delegated to at
+# the end of this file (see test-session-start-handoff.sh).
 #
 # Usage: ./hooks/repo/tests/run.sh
 # Exit status: 0 if all cases pass, 1 otherwise.
@@ -159,6 +161,26 @@ rm -rf "$CFG_REPO" "$LOOM_REPO"
 echo "-- edge: cwd absent / non-git --"
 expect deny  "rm -rf / with empty cwd"         "" "rm -rf /"
 expect allow "ls with nonexistent cwd"         "/nonexistent/path/xyz" "ls"
+
+# The SessionStart handoff hook ships its own suite rather than inline cases:
+# its payload shape, assertions, and install/uninstall wiring checks share
+# nothing with the guard's expect() helper above. Delegate to it and fold the
+# verdict in as a single case so `pnpm test` covers both hooks.
+echo
+echo "-- session-start-handoff.sh (delegated suite) --"
+SS_TEST="$TESTS_DIR/test-session-start-handoff.sh"
+if [[ ! -f "$SS_TEST" ]]; then
+    FAIL=$((FAIL + 1))
+    printf '  FAIL %-52s -> not found at %s\n' "test-session-start-handoff.sh" "$SS_TEST"
+elif SS_OUT="$(bash "$SS_TEST" 2>&1)"; then
+    PASS=$((PASS + 1))
+    printf '  ok   %-52s -> %s\n' "test-session-start-handoff.sh" \
+        "$(printf '%s\n' "$SS_OUT" | awk '/^  Total:/ {print $2 " cases pass"}')"
+else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL %-52s -> suite failed; output follows\n' "test-session-start-handoff.sh"
+    printf '%s\n' "$SS_OUT" | sed 's/^/    /'
+fi
 
 echo
 echo "==============================="

--- a/hooks/repo/tests/test-session-start-handoff.sh
+++ b/hooks/repo/tests/test-session-start-handoff.sh
@@ -1,0 +1,425 @@
+#!/usr/bin/env bash
+# Test suite for hooks/repo/session-start-handoff.sh (and the install.sh /
+# uninstall.sh settings.json wiring that installs it).
+#
+# Usage: ./hooks/repo/tests/test-session-start-handoff.sh
+# Exit code 0 = all tests pass, 1 = failures detected.
+#
+# Structured like test-guard-destructive.sh next door: pure bash, no test
+# framework, PASS/FAIL counters and a summary block. Each hook case pipes a
+# synthetic Claude Code SessionStart payload ({"cwd":...,"source":...}) to the
+# hook and asserts on stdout + exit status.
+#
+# The contract under test (see the hook's header):
+#   - fires only for source "startup"/"resume"
+#   - emits hookSpecificOutput.hookEventName == "SessionStart" with
+#     additionalContext summarizing .claude/handoff.md (path, age, staleness,
+#     section headers only)
+#   - never exits non-zero, never emits malformed JSON, never writes the note
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+HOOK="$REPO_ROOT/hooks/repo/session-start-handoff.sh"
+INSTALL_SH="$REPO_ROOT/install.sh"
+UNINSTALL_SH="$REPO_ROOT/uninstall.sh"
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+if [[ ! -f "$HOOK" ]]; then
+    echo "FATAL: hook not found at $HOOK" >&2
+    exit 1
+fi
+if ! command -v jq >/dev/null 2>&1; then
+    echo "FATAL: jq is required to run these tests" >&2
+    exit 1
+fi
+
+# Resolve to a PHYSICAL path: on macOS mktemp -d hands back /var/folders/... but
+# `git rev-parse --show-toplevel` reports /private/var/folders/..., and the hook
+# emits git's answer. Without `pwd -P` here every path assertion below would
+# compare the two spellings and fail.
+SCRATCH="$(cd "$(mktemp -d)" && pwd -P)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+# ---------------------------------------------------------------------------
+# Assertion helpers
+# ---------------------------------------------------------------------------
+
+ok() {   # <label>
+    TOTAL=$((TOTAL + 1)); PASS=$((PASS + 1))
+    printf "  ${GREEN}PASS${NC}: %s\n" "$1"
+}
+no() {   # <label> <detail>
+    TOTAL=$((TOTAL + 1)); FAIL=$((FAIL + 1))
+    printf "  ${RED}FAIL${NC}: %s\n" "$1"
+    [[ -n "${2:-}" ]] && printf "        %s\n" "$2"
+}
+assert_eq() {  # <label> <expected> <actual>
+    if [[ "$2" == "$3" ]]; then ok "$1"; else no "$1" "expected [$2], got [$3]"; fi
+}
+assert_contains() {  # <label> <haystack> <needle>
+    if [[ "$2" == *"$3"* ]]; then ok "$1"; else no "$1" "missing [$3] in output"; fi
+}
+assert_not_contains() {  # <label> <haystack> <needle>
+    if [[ "$2" != *"$3"* ]]; then ok "$1"; else no "$1" "unexpected [$3] present in output"; fi
+}
+assert_empty() {  # <label> <actual>
+    if [[ -z "$2" ]]; then ok "$1"; else no "$1" "expected no output, got [$2]"; fi
+}
+
+# run_hook <cwd> <source> -> stdout on HOOK_OUT, exit status in HOOK_EXIT.
+# A raw stdin payload can be supplied instead via run_hook_raw.
+HOOK_OUT=""
+HOOK_EXIT=0
+run_hook_raw() {  # <stdin-payload>
+    HOOK_OUT=$(printf '%s' "$1" | bash "$HOOK" 2>/dev/null)
+    HOOK_EXIT=$?
+}
+run_hook() {  # <cwd> <source>
+    run_hook_raw "$(jq -nc --arg w "$1" --arg s "$2" '{cwd:$w, source:$s}')"
+}
+
+# Portable "N units ago" mtime setter (BSD `date -v` vs GNU `date -d`).
+set_mtime_ago() {  # <file> <bsd-spec e.g. -8d> <gnu-spec e.g. "8 days ago">
+    local stamp
+    stamp=$(date -v"$2" +%Y%m%d%H%M 2>/dev/null) || stamp=""
+    [[ -n "$stamp" ]] || stamp=$(date -d "$3" +%Y%m%d%H%M 2>/dev/null) || stamp=""
+    if [[ -z "$stamp" ]]; then
+        echo "FATAL: neither BSD nor GNU date available for relative timestamps" >&2
+        exit 1
+    fi
+    touch -t "$stamp" "$1"
+}
+
+# A throwaway git repo with a handoff note in it.
+make_repo() {  # <name> -> echoes path
+    local d="$SCRATCH/$1"
+    mkdir -p "$d/.claude"
+    git -C "$d" init -q 2>/dev/null || { git init -q "$d"; }
+    printf '%s' "$d"
+}
+
+NOTE_BODY='# Handoff — 2026-07-27
+
+Prose that must never be injected wholesale.
+
+## 1. In-flight — resolve before anything else
+
+PR #41 awaits review. [verified]
+
+## 2. Decisions — settled, do not relitigate
+
+The shell wrapper is deferred. [verified]
+
+## 3. The precise next action
+
+Run the test suite.
+'
+
+echo "session-start-handoff.sh test suite"
+echo "==================================="
+echo ""
+
+# ---------------------------------------------------------------------------
+echo "-- fresh note present --"
+# ---------------------------------------------------------------------------
+FRESH="$(make_repo fresh)"
+printf '%s' "$NOTE_BODY" > "$FRESH/.claude/handoff.md"
+
+run_hook "$FRESH" startup
+assert_eq        "startup: exit 0"                       "0" "$HOOK_EXIT"
+if printf '%s' "$HOOK_OUT" | jq -e . >/dev/null 2>&1; then
+    ok "startup: stdout is well-formed JSON"
+else
+    no "startup: stdout is well-formed JSON" "got [$HOOK_OUT]"
+fi
+EVENT=$(printf '%s' "$HOOK_OUT" | jq -r '.hookSpecificOutput.hookEventName // ""' 2>/dev/null)
+assert_eq        "startup: hookEventName is SessionStart" "SessionStart" "$EVENT"
+CTX=$(printf '%s' "$HOOK_OUT" | jq -r '.hookSpecificOutput.additionalContext // ""' 2>/dev/null)
+assert_contains  "startup: context names the note path"   "$CTX" "$FRESH/.claude/handoff.md"
+assert_contains  "startup: context reports age"           "$CTX" "just now"
+assert_contains  "startup: renders a section header"      "$CTX" "1. In-flight — resolve before anything else"
+assert_contains  "startup: renders the title header"      "$CTX" "Handoff — 2026-07-27"
+assert_not_contains "startup: omits note body prose"      "$CTX" "PR #41 awaits review"
+assert_not_contains "startup: fresh note is not stale"    "$CTX" "STALE"
+# Exactly one JSON object on stdout (a second would corrupt the hook protocol).
+LINES=$(printf '%s' "$HOOK_OUT" | grep -c . || true)
+assert_eq        "startup: exactly one output line"       "1" "$LINES"
+
+run_hook "$FRESH" resume
+assert_eq        "resume: exit 0"                         "0" "$HOOK_EXIT"
+EVENT=$(printf '%s' "$HOOK_OUT" | jq -r '.hookSpecificOutput.hookEventName // ""' 2>/dev/null)
+assert_eq        "resume: also fires"                     "SessionStart" "$EVENT"
+
+# Read-only guarantee: content and mtime are untouched by the hook.
+BEFORE_SUM=$(cksum < "$FRESH/.claude/handoff.md")
+BEFORE_MTIME=$(stat -f %m "$FRESH/.claude/handoff.md" 2>/dev/null || stat -c %Y "$FRESH/.claude/handoff.md")
+run_hook "$FRESH" startup
+AFTER_SUM=$(cksum < "$FRESH/.claude/handoff.md")
+AFTER_MTIME=$(stat -f %m "$FRESH/.claude/handoff.md" 2>/dev/null || stat -c %Y "$FRESH/.claude/handoff.md")
+assert_eq        "read-only: note content unchanged"      "$BEFORE_SUM" "$AFTER_SUM"
+assert_eq        "read-only: note mtime unchanged"        "$BEFORE_MTIME" "$AFTER_MTIME"
+
+# Resolves the repo root from a subdirectory cwd, not just the root itself.
+mkdir -p "$FRESH/src/deep"
+run_hook "$FRESH/src/deep" startup
+CTX=$(printf '%s' "$HOOK_OUT" | jq -r '.hookSpecificOutput.additionalContext // ""' 2>/dev/null)
+assert_contains  "subdir cwd: resolves repo root note"    "$CTX" "$FRESH/.claude/handoff.md"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "-- age labelling and staleness --"
+# ---------------------------------------------------------------------------
+AGED="$(make_repo aged)"
+printf '%s' "$NOTE_BODY" > "$AGED/.claude/handoff.md"
+
+set_mtime_ago "$AGED/.claude/handoff.md" -5H "5 hours ago"
+run_hook "$AGED" startup
+CTX=$(printf '%s' "$HOOK_OUT" | jq -r '.hookSpecificOutput.additionalContext // ""' 2>/dev/null)
+assert_contains  "5h old: hour-granularity age label"     "$CTX" "5h old"
+assert_not_contains "5h old: not flagged stale"           "$CTX" "STALE"
+
+set_mtime_ago "$AGED/.claude/handoff.md" -3d "3 days ago"
+run_hook "$AGED" startup
+CTX=$(printf '%s' "$HOOK_OUT" | jq -r '.hookSpecificOutput.additionalContext // ""' 2>/dev/null)
+assert_contains  "3d old: day-granularity age label"      "$CTX" "3d old"
+assert_not_contains "3d old: not yet stale (<7d)"         "$CTX" "STALE"
+
+set_mtime_ago "$AGED/.claude/handoff.md" -8d "8 days ago"
+run_hook "$AGED" startup
+assert_eq        "8d old: exit 0"                         "0" "$HOOK_EXIT"
+CTX=$(printf '%s' "$HOOK_OUT" | jq -r '.hookSpecificOutput.additionalContext // ""' 2>/dev/null)
+assert_contains  "8d old: age label"                      "$CTX" "8d old"
+assert_contains  "8d old: flagged STALE (>=7d)"           "$CTX" "STALE"
+
+# The 7d boundary itself is stale; 6d is not.
+set_mtime_ago "$AGED/.claude/handoff.md" -6d "6 days ago"
+run_hook "$AGED" startup
+CTX=$(printf '%s' "$HOOK_OUT" | jq -r '.hookSpecificOutput.additionalContext // ""' 2>/dev/null)
+assert_not_contains "6d old: below the stale threshold"   "$CTX" "STALE"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "-- header rendering is capped and headers-only --"
+# ---------------------------------------------------------------------------
+MANY="$(make_repo many)"
+{
+    for i in 1 2 3 4 5 6 7 8 9 10 11 12; do
+        echo "## Section $i"
+        echo "body-line-$i should never be injected"
+        echo ""
+    done
+    echo "### Deep heading level three"
+} > "$MANY/.claude/handoff.md"
+run_hook "$MANY" startup
+CTX=$(printf '%s' "$HOOK_OUT" | jq -r '.hookSpecificOutput.additionalContext // ""' 2>/dev/null)
+assert_contains     "cap: first header rendered"          "$CTX" "Section 1"
+assert_contains     "cap: ninth header rendered"          "$CTX" "Section 9"
+assert_not_contains "cap: tenth header dropped"           "$CTX" "Section 10"
+assert_not_contains "cap: body lines never injected"      "$CTX" "body-line-1 should never be injected"
+assert_not_contains "cap: h3 headings not treated as sections" "$CTX" "Deep heading level three"
+
+# A note with no headers at all is still announced (path + age), no crash.
+NOHDR="$(make_repo nohdr)"
+printf 'just some prose, no headings at all\n' > "$NOHDR/.claude/handoff.md"
+run_hook "$NOHDR" startup
+assert_eq        "no headers: exit 0"                     "0" "$HOOK_EXIT"
+CTX=$(printf '%s' "$HOOK_OUT" | jq -r '.hookSpecificOutput.additionalContext // ""' 2>/dev/null)
+assert_contains  "no headers: still announces the note"   "$CTX" "$NOHDR/.claude/handoff.md"
+assert_not_contains "no headers: prose not injected"      "$CTX" "just some prose"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "-- silent no-op paths --"
+# ---------------------------------------------------------------------------
+EMPTY="$(make_repo empty)"
+run_hook "$EMPTY" startup
+assert_eq        "no note: exit 0"                        "0" "$HOOK_EXIT"
+assert_empty     "no note: no output"                     "$HOOK_OUT"
+
+# Non-startup/resume sources are silent even when the note is present.
+for src in clear compact fork; do
+    run_hook "$FRESH" "$src"
+    assert_eq    "source=$src: exit 0"                    "0" "$HOOK_EXIT"
+    assert_empty "source=$src: no output despite note"    "$HOOK_OUT"
+done
+
+# Unreadable note (chmod 000) behaves like an absent one. Skipped when running
+# as root, where the read succeeds regardless of mode bits.
+if [[ "$(id -u)" != "0" ]]; then
+    UNREAD="$(make_repo unreadable)"
+    printf '%s' "$NOTE_BODY" > "$UNREAD/.claude/handoff.md"
+    chmod 000 "$UNREAD/.claude/handoff.md"
+    run_hook "$UNREAD" startup
+    assert_eq    "unreadable note: exit 0"                "0" "$HOOK_EXIT"
+    assert_empty "unreadable note: no output"             "$HOOK_OUT"
+    chmod 644 "$UNREAD/.claude/handoff.md"
+fi
+
+# A directory named .claude/handoff.md is not a readable note.
+DIRNOTE="$(make_repo dirnote)"
+mkdir -p "$DIRNOTE/.claude/handoff.md"
+run_hook "$DIRNOTE" startup
+assert_eq        "handoff.md is a directory: exit 0"      "0" "$HOOK_EXIT"
+assert_empty     "handoff.md is a directory: no output"   "$HOOK_OUT"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "-- fail-open on malformed / missing input --"
+# ---------------------------------------------------------------------------
+run_hook_raw ''
+assert_eq        "empty stdin: exit 0"                    "0" "$HOOK_EXIT"
+assert_empty     "empty stdin: no output"                 "$HOOK_OUT"
+
+run_hook_raw 'not json at all {{{'
+assert_eq        "malformed JSON: exit 0"                 "0" "$HOOK_EXIT"
+assert_empty     "malformed JSON: no output"              "$HOOK_OUT"
+
+run_hook_raw '{"source":"startup"}'
+assert_eq        "missing cwd: exit 0"                    "0" "$HOOK_EXIT"
+assert_empty     "missing cwd: no output"                 "$HOOK_OUT"
+
+run_hook_raw "$(jq -nc --arg w "$FRESH" '{cwd:$w}')"
+assert_eq        "missing source: exit 0"                 "0" "$HOOK_EXIT"
+assert_empty     "missing source: no output"              "$HOOK_OUT"
+
+run_hook_raw '{"cwd":"/nonexistent/path/xyz","source":"startup"}'
+assert_eq        "nonexistent cwd: exit 0"                "0" "$HOOK_EXIT"
+assert_empty     "nonexistent cwd: no output"             "$HOOK_OUT"
+
+run_hook_raw '[]'
+assert_eq        "JSON array payload: exit 0"             "0" "$HOOK_EXIT"
+assert_empty     "JSON array payload: no output"          "$HOOK_OUT"
+
+# Non-git cwd falls back to treating cwd itself as the root (the original
+# proposal's `root=$(git rev-parse --show-toplevel) || root=$PWD`).
+NOGIT="$SCRATCH/nogit"
+mkdir -p "$NOGIT/.claude"
+printf '%s' "$NOTE_BODY" > "$NOGIT/.claude/handoff.md"
+run_hook "$NOGIT" startup
+assert_eq        "non-git cwd: exit 0"                    "0" "$HOOK_EXIT"
+CTX=$(printf '%s' "$HOOK_OUT" | jq -r '.hookSpecificOutput.additionalContext // ""' 2>/dev/null)
+assert_contains  "non-git cwd: falls back to cwd as root" "$CTX" "$NOGIT/.claude/handoff.md"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "-- install.sh / uninstall.sh settings.json wiring --"
+# ---------------------------------------------------------------------------
+SS_CMD='${CLAUDE_PROJECT_DIR}/.claude/skills/repo/hooks/session-start-handoff.sh'
+GUARD_CMD='${CLAUDE_PROJECT_DIR}/.claude/skills/repo/hooks/guard-destructive.sh'
+
+count_entries() {  # <settings> <command> -> total number of matching hook entries
+    jq --arg c "$2" '[(.hooks.SessionStart // [])[] | (.hooks // [])[] | select(.command == $c)] | length' "$1"
+}
+
+TGT="$SCRATCH/target"
+mkdir -p "$TGT"
+git init -q "$TGT" 2>/dev/null
+bash "$INSTALL_SH" -y "$TGT" >/dev/null 2>&1
+INSTALL_RC=$?
+assert_eq        "install: exits 0"                       "0" "$INSTALL_RC"
+
+if [[ -f "$TGT/.claude/skills/repo/hooks/session-start-handoff.sh" ]]; then
+    ok "install: hook script copied into the target"
+else
+    no "install: hook script copied into the target"
+fi
+if [[ -x "$TGT/.claude/skills/repo/hooks/session-start-handoff.sh" ]]; then
+    ok "install: hook script is executable"
+else
+    no "install: hook script is executable"
+fi
+
+SETTINGS="$TGT/.claude/settings.json"
+assert_eq "install: wired under matcher startup" "1" \
+    "$(jq --arg c "$SS_CMD" '[(.hooks.SessionStart // [])[] | select(.matcher == "startup") | (.hooks // [])[] | select(.command == $c)] | length' "$SETTINGS")"
+assert_eq "install: wired under matcher resume"  "1" \
+    "$(jq --arg c "$SS_CMD" '[(.hooks.SessionStart // [])[] | select(.matcher == "resume") | (.hooks // [])[] | select(.command == $c)] | length' "$SETTINGS")"
+assert_eq "install: no clear/compact/fork matcher wired" "0" \
+    "$(jq '[(.hooks.SessionStart // [])[] | select(.matcher == "clear" or .matcher == "compact" or .matcher == "fork")] | length' "$SETTINGS")"
+assert_eq "install: PreToolUse guard still wired alongside" "1" \
+    "$(jq --arg c "$GUARD_CMD" '[(.hooks.PreToolUse // [])[] | (.hooks // [])[] | select(.command == $c)] | length' "$SETTINGS")"
+
+# Idempotency: a second install must not duplicate the entries.
+bash "$INSTALL_SH" -y "$TGT" >/dev/null 2>&1
+assert_eq "re-install: still exactly 2 SessionStart entries" "2" "$(count_entries "$SETTINGS" "$SS_CMD")"
+
+# Coexistence: a hand-authored SessionStart hook survives install and uninstall,
+# including one sharing our "startup" matcher group.
+jq '.hooks.SessionStart += [{matcher: "clear", hooks: [{type: "command", command: "/usr/local/bin/mine.sh"}]}]
+    | .hooks.SessionStart |= map(if .matcher == "startup"
+        then .hooks += [{type: "command", command: "/usr/local/bin/also-mine.sh"}] else . end)' \
+   "$SETTINGS" > "$SETTINGS.tmp" && mv "$SETTINGS.tmp" "$SETTINGS"
+bash "$INSTALL_SH" -y "$TGT" >/dev/null 2>&1
+assert_eq "coexist: foreign clear hook preserved by install" "1" \
+    "$(jq '[(.hooks.SessionStart // [])[] | (.hooks // [])[] | select(.command == "/usr/local/bin/mine.sh")] | length' "$SETTINGS")"
+assert_eq "coexist: foreign startup hook preserved by install" "1" \
+    "$(jq '[(.hooks.SessionStart // [])[] | (.hooks // [])[] | select(.command == "/usr/local/bin/also-mine.sh")] | length' "$SETTINGS")"
+assert_eq "coexist: ours still not duplicated" "2" "$(count_entries "$SETTINGS" "$SS_CMD")"
+
+bash "$UNINSTALL_SH" -y "$TGT" >/dev/null 2>&1
+UNINSTALL_RC=$?
+assert_eq "uninstall: exits 0"                            "0" "$UNINSTALL_RC"
+assert_eq "uninstall: our SessionStart entries removed"   "0" "$(count_entries "$SETTINGS" "$SS_CMD")"
+assert_eq "uninstall: foreign clear hook survives"        "1" \
+    "$(jq '[(.hooks.SessionStart // [])[] | (.hooks // [])[] | select(.command == "/usr/local/bin/mine.sh")] | length' "$SETTINGS")"
+assert_eq "uninstall: foreign startup hook survives"      "1" \
+    "$(jq '[(.hooks.SessionStart // [])[] | (.hooks // [])[] | select(.command == "/usr/local/bin/also-mine.sh")] | length' "$SETTINGS")"
+assert_eq "uninstall: PreToolUse guard entry also removed" "0" \
+    "$(jq --arg c "$GUARD_CMD" '[(.hooks.PreToolUse // [])[] | (.hooks // [])[] | select(.command == $c)] | length' "$SETTINGS")"
+if [[ -e "$TGT/.claude/skills/repo/hooks/session-start-handoff.sh" ]]; then
+    no "uninstall: hook script removed"
+else
+    ok "uninstall: hook script removed"
+fi
+
+# Empty-container pruning: a settings.json holding ONLY our entries loses
+# .hooks.SessionStart entirely rather than leaving empty litter.
+TGT2="$SCRATCH/target2"
+mkdir -p "$TGT2"
+git init -q "$TGT2" 2>/dev/null
+bash "$INSTALL_SH" -y "$TGT2" >/dev/null 2>&1
+bash "$UNINSTALL_SH" -y "$TGT2" >/dev/null 2>&1
+if [[ -f "$TGT2/.claude/settings.json" ]]; then
+    assert_eq "prune: SessionStart container removed when empty" "false" \
+        "$(jq -c 'has("hooks") and (.hooks | has("SessionStart"))' "$TGT2/.claude/settings.json")"
+else
+    ok "prune: SessionStart container removed when empty (settings.json itself pruned)"
+fi
+
+# --dry-run must enumerate the new file and the new wiring line.
+TGT3="$SCRATCH/target3"
+mkdir -p "$TGT3"
+git init -q "$TGT3" 2>/dev/null
+DRY=$(bash "$INSTALL_SH" --dry-run "$TGT3" 2>&1)
+assert_contains "dry-run: lists the hook script"      "$DRY" "hooks/session-start-handoff.sh"
+assert_contains "dry-run: lists the SessionStart wiring" "$DRY" "merge SessionStart"
+assert_contains "dry-run: names the wired sources"    "$DRY" "startup resume"
+if [[ -f "$TGT3/.claude/settings.json" ]]; then
+    no "dry-run: writes nothing" "settings.json was created"
+else
+    ok "dry-run: writes nothing"
+fi
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "========================================="
+echo "  Total:  $TOTAL"
+printf "  ${GREEN}Passed${NC}: %s\n" "$PASS"
+printf "  ${RED}Failed${NC}: %s\n" "$FAIL"
+echo "========================================="
+
+if [[ $FAIL -gt 0 ]]; then
+    printf "\n${RED}TESTS FAILED${NC}\n"
+    exit 1
+fi
+printf "\n${GREEN}ALL TESTS PASSED${NC}\n"
+exit 0

--- a/install.sh
+++ b/install.sh
@@ -180,6 +180,27 @@ else
   COMMANDS="$ALL_COMMANDS"
 fi
 
+# Hook install paths and the commands Claude Code resolves them to
+# (${CLAUDE_PROJECT_DIR} expands to the consumer repo root at hook time).
+# Declared before the --dry-run enumeration below so that listing and doing
+# read from the same constants and cannot drift.
+HOOK_INSTALL_REL=".claude/skills/repo/hooks/guard-destructive.sh"
+HOOK_CMD="\${CLAUDE_PROJECT_DIR}/${HOOK_INSTALL_REL}"
+
+# The SessionStart handoff hook, same resolution. Claude Code's SessionStart
+# matchers key on the session SOURCE ("startup" | "resume" | "clear" |
+# "compact" | "fork"), not on a tool name. We wire the two literal sources the
+# hook acts on rather than an alternation like "startup|resume": alternation is
+# documented for tool matchers but NOT for SessionStart, and a matcher that
+# silently matched nothing would leave the hook inert with no error. Two literal
+# entries use only documented values. The hook re-checks .source itself, so this
+# is belt-and-braces rather than a load-bearing filter.
+SESSIONSTART_HOOK_INSTALL_REL=".claude/skills/repo/hooks/session-start-handoff.sh"
+SESSIONSTART_HOOK_CMD="\${CLAUDE_PROJECT_DIR}/${SESSIONSTART_HOOK_INSTALL_REL}"
+SESSIONSTART_SOURCES=(startup resume)
+
+SETTINGS_JSON="$TARGET/.claude/settings.json"
+
 echo ""
 info "Repo Skills v$VERSION ($COMMIT) → $TARGET"
 [[ "$DEV" == true ]] && info "Dev mode: symlinking source files (edits are live)"
@@ -194,7 +215,9 @@ if [[ "$DRY_RUN" == true ]]; then
   echo "  $TARGET/.claude/skills/repo/install-metadata.json"
   echo "  $TARGET/.claude/skills/repo/.install-local.json (machine-local, gitignored)"
   echo "  $TARGET/.claude/skills/repo/hooks/guard-destructive.sh"
+  echo "  $TARGET/.claude/skills/repo/hooks/session-start-handoff.sh"
   echo "  $TARGET/.claude/settings.json (merge PreToolUse→Bash guard hook; idempotent, coexistence-aware)"
+  echo "  $TARGET/.claude/settings.json (merge SessionStart→${SESSIONSTART_SOURCES[*]} handoff-note hook; idempotent, coexistence-aware)"
   while IFS= read -r cmd; do
     echo "  $TARGET/.claude/commands/repo/$cmd.md"
   done <<<"$COMMANDS"
@@ -231,12 +254,6 @@ install_file() {  # <source-abs> <dest-abs> <label>
     assert_no_placeholders "$2" "$3"
   fi
 }
-
-# The PreToolUse guard hook's installed command, as Claude Code resolves it
-# (${CLAUDE_PROJECT_DIR} expands to the consumer repo root at hook time).
-HOOK_INSTALL_REL=".claude/skills/repo/hooks/guard-destructive.sh"
-HOOK_CMD="\${CLAUDE_PROJECT_DIR}/${HOOK_INSTALL_REL}"
-SETTINGS_JSON="$TARGET/.claude/settings.json"
 
 # Idempotently wire the guard-destructive.sh PreToolUse/Bash hook into the
 # target's .claude/settings.json WITHOUT clobbering anything else in the file.
@@ -289,6 +306,66 @@ merge_settings_hook() {
       ' "$settings" >"$tmp"; then
     mv "$tmp" "$settings"
     success "Wired PreToolUse guard into .claude/settings.json"
+  else
+    rm -f "$tmp"
+    warning "Failed to update $settings — left unchanged"
+  fi
+}
+
+# Idempotently wire session-start-handoff.sh into the target's
+# .claude/settings.json under hooks.SessionStart, once per managed source
+# matcher. Same discipline as merge_settings_hook above: refuse to touch
+# malformed JSON, no-op when already wired, defer to an equivalent hook someone
+# else wired, and write via temp-file-and-mv so a mid-read jq failure can never
+# truncate the consumer's settings. Existing SessionStart entries — hand-authored
+# or another tool's — are appended to, never replaced.
+merge_settings_sessionstart_hook() {
+  local settings="$SETTINGS_JSON" cmd="$SESSIONSTART_HOOK_CMD" tmp sources_json
+  sources_json="$(jq -nc '$ARGS.positional' --args "${SESSIONSTART_SOURCES[@]}")"
+  [[ -f "$settings" ]] || echo '{}' >"$settings"
+
+  if ! jq -e . "$settings" >/dev/null 2>&1; then
+    warning "Skipping SessionStart hook wiring: $settings is not valid JSON (wire it by hand)"
+    return
+  fi
+
+  # Idempotent re-install: our exact command is already present under EVERY
+  # source matcher we manage (a partial wiring falls through and is completed).
+  if jq -e --arg c "$cmd" --argjson sources "$sources_json" '
+        (.hooks.SessionStart // []) as $ss |
+        ($sources | all(. as $m | $ss | any(.[]?;
+          (.matcher == $m) and ((.hooks // []) | any(.[]?; .command == $c)))))
+      ' "$settings" >/dev/null 2>&1; then
+    info "SessionStart handoff hook already wired in .claude/settings.json (no change)"
+    return
+  fi
+
+  # Coexistence: a DIFFERENT session-start-handoff.sh is already wired (e.g. a
+  # copy living at another path). Defer rather than surfacing the note twice.
+  if jq -e --arg c "$cmd" '
+        (.hooks.SessionStart // []) | any(.[]?;
+          (.hooks // []) | any(.[]?;
+            ((.command // "") | test("session-start-handoff\\.sh")) and (.command != $c)))
+      ' "$settings" >/dev/null 2>&1; then
+    info "A handoff SessionStart hook is already wired in .claude/settings.json — deferring to it (not adding a duplicate)"
+    return
+  fi
+
+  tmp="$(mktemp)"
+  if jq --arg c "$cmd" --argjson sources "$sources_json" '
+        .hooks //= {} |
+        .hooks.SessionStart //= [] |
+        reduce ($sources[]) as $m (.;
+          if (.hooks.SessionStart | any(.[]?; .matcher == $m))
+          then .hooks.SessionStart |= map(
+            if (.matcher == $m) and (((.hooks // []) | any(.[]?; .command == $c)) | not)
+            then .hooks = ((.hooks // []) + [{type: "command", command: $c}])
+            else . end)
+          else .hooks.SessionStart += [{matcher: $m, hooks: [{type: "command", command: $c}]}]
+          end)
+      ' "$settings" >"$tmp"; then
+    mv "$tmp" "$settings"
+    success "Wired SessionStart handoff hook into .claude/settings.json"
   else
     rm -f "$tmp"
     warning "Failed to update $settings — left unchanged"
@@ -363,6 +440,17 @@ install_file "$SOURCE_ROOT/hooks/repo/guard-destructive.sh" \
 chmod +x "$TARGET/.claude/skills/repo/hooks/guard-destructive.sh" 2>/dev/null || true
 success "Installed .claude/skills/repo/hooks/guard-destructive.sh"
 merge_settings_hook
+
+# 3c. SessionStart handoff hook + settings.json wiring. Same colocation and
+# chmod rationale as the guard above. Wired unconditionally, like the guard:
+# both the script and its settings entry live entirely inside the target repo,
+# so there is nothing to gate behind a confirm and behaviour is identical with
+# and without --yes.
+install_file "$SOURCE_ROOT/hooks/repo/session-start-handoff.sh" \
+  "$TARGET/.claude/skills/repo/hooks/session-start-handoff.sh" "hooks/repo/session-start-handoff.sh"
+chmod +x "$TARGET/.claude/skills/repo/hooks/session-start-handoff.sh" 2>/dev/null || true
+success "Installed .claude/skills/repo/hooks/session-start-handoff.sh"
+merge_settings_sessionstart_hook
 
 # 4. CLAUDE.md block (replace existing block in place, else append).
 # Skipped in dev mode: the symlinked install is machine-local (absolute symlinks

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -22,6 +22,11 @@ MARKER_END='<!-- END REPO-SKILLS -->'
 # skills dir below; only this settings.json entry needs explicit removal.
 HOOK_CMD="\${CLAUDE_PROJECT_DIR}/.claude/skills/repo/hooks/guard-destructive.sh"
 
+# Likewise for the SessionStart handoff hook install.sh wires under one entry
+# per session source ("startup", "resume"). Its script also lives under
+# .claude/skills/repo/hooks/ and goes with the skills dir.
+SESSIONSTART_HOOK_CMD="\${CLAUDE_PROJECT_DIR}/.claude/skills/repo/hooks/session-start-handoff.sh"
+
 # Remove only the Repo-Skills-owned PreToolUse/Bash hook entry from
 # .claude/settings.json, leaving any other entries (a hand-authored hook, or
 # Loom's own guard) untouched, and pruning containers that become empty so no
@@ -50,6 +55,35 @@ remove_settings_hook() {  # <settings-path>
   fi
 }
 
+# Mirror image of the above for the SessionStart handoff hook: remove only
+# entries whose command is exactly ours, across every source matcher, then prune
+# matcher groups and containers that become empty. A hand-authored SessionStart
+# hook — or another tool's — is left untouched, including one sharing the same
+# "startup"/"resume" matcher group.
+remove_settings_sessionstart_hook() {  # <settings-path>
+  local settings="$1" tmp
+  [[ -f "$settings" ]] || return 0
+  jq -e . "$settings" >/dev/null 2>&1 || return 0
+  # Only act if our command is actually present.
+  jq -e --arg c "$SESSIONSTART_HOOK_CMD" \
+    '(.hooks.SessionStart // []) | any(.[]?; (.hooks // []) | any(.[]?; .command == $c))' \
+    "$settings" >/dev/null 2>&1 || return 0
+  tmp="$(mktemp)"
+  if jq --arg c "$SESSIONSTART_HOOK_CMD" '
+        if (.hooks.SessionStart | type) == "array" then
+          .hooks.SessionStart |= map(.hooks |= ((. // []) | map(select(.command != $c))))
+          | .hooks.SessionStart |= map(select(((.hooks // []) | length) > 0))
+          | (if (.hooks.SessionStart | length) == 0 then .hooks |= del(.SessionStart) else . end)
+          | (if (.hooks | length) == 0 then del(.hooks) else . end)
+        else . end
+      ' "$settings" >"$tmp"; then
+    mv "$tmp" "$settings"
+    success "Removed SessionStart handoff entry from .claude/settings.json"
+  else
+    rm -f "$tmp"
+  fi
+}
+
 TARGET=""
 YES=false
 for arg in "$@"; do
@@ -68,13 +102,18 @@ TARGET="$(cd "$TARGET" 2>/dev/null && pwd)" || error "Target directory does not 
   || { info "No Repo Skills install found in $TARGET"; exit 0; }
 
 echo "Will remove from $TARGET:"
-[[ -d "$TARGET/.claude/skills/repo" ]]   && echo "  .claude/skills/repo/ (incl. hooks/guard-destructive.sh)"
+[[ -d "$TARGET/.claude/skills/repo" ]]   && echo "  .claude/skills/repo/ (incl. hooks/guard-destructive.sh, hooks/session-start-handoff.sh)"
 [[ -d "$TARGET/.claude/commands/repo" ]] && echo "  .claude/commands/repo/"
 grep -qF "$MARKER_BEGIN" "$TARGET/CLAUDE.md" 2>/dev/null && echo "  CLAUDE.md REPO-SKILLS block"
 if [[ -f "$TARGET/.claude/settings.json" ]] && \
    jq -e --arg c "$HOOK_CMD" '(.hooks.PreToolUse // []) | any(.[]?; (.hooks // []) | any(.[]?; .command == $c))' \
      "$TARGET/.claude/settings.json" >/dev/null 2>&1; then
   echo "  .claude/settings.json PreToolUse guard entry"
+fi
+if [[ -f "$TARGET/.claude/settings.json" ]] && \
+   jq -e --arg c "$SESSIONSTART_HOOK_CMD" '(.hooks.SessionStart // []) | any(.[]?; (.hooks // []) | any(.[]?; .command == $c))' \
+     "$TARGET/.claude/settings.json" >/dev/null 2>&1; then
+  echo "  .claude/settings.json SessionStart handoff entry"
 fi
 
 if [[ "$YES" != true ]]; then
@@ -89,6 +128,7 @@ success "Removed skill and command directories"
 # rmdir below can clean up an empty .claude if settings.json was the only file.
 if command -v jq >/dev/null 2>&1; then
   remove_settings_hook "$TARGET/.claude/settings.json"
+  remove_settings_sessionstart_hook "$TARGET/.claude/settings.json"
 fi
 
 rmdir "$TARGET/.claude/skills" "$TARGET/.claude/commands" "$TARGET/.claude" 2>/dev/null || true


### PR DESCRIPTION
## Summary

`/repo:handoff` writes `.claude/handoff.md` and adds a pointer to the agent's memory index, but nothing *announces* the note at session start — and the command's one-shot "read it, then delete it" contract means a note that never gets absorbed lingers silently. `handoff.md` itself calls a stale handoff "a trap of its own"; nothing surfaced that staleness.

This implements the curated scope: a **`SessionStart` hook only**. The shell `claude` wrapper from the original proposal is deliberately **not** implemented (see Out of Scope).

## Changes

- **NEW `hooks/repo/session-start-handoff.sh`** — read-only `SessionStart` hook. Parses the payload from stdin (`.cwd`, `.source`), resolves the repo root via `git rev-parse --show-toplevel` (falling back to `cwd`), and emits `{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"..."}}` with the note's path, age, a `STALE` flag past 7 days, and a **headers-only** summary (`^#{1,2} `, capped at 9 — never the body; the real note that motivated this was 7.5 KB). Portable mtime (BSD `stat -f %m` → GNU `stat -c %Y`). Follows `guard-destructive.sh`'s conventions: `ERR` trap, diagnostics to `../logs/hook-errors.log`, **always exit 0**, never malformed output.
- **NEW `hooks/repo/tests/test-session-start-handoff.sh`** — 79 cases.
- **`hooks/repo/tests/run.sh`** — delegates to the new suite so `pnpm test` covers both hooks.
- **`install.sh`** — installs + `chmod +x` the script alongside `guard-destructive.sh`; new `merge_settings_sessionstart_hook()` mirroring `merge_settings_hook()`; hook constants moved above the `--dry-run` enumeration so listing and doing read from the same values; `--dry-run` extended.
- **`uninstall.sh`** — new `remove_settings_sessionstart_hook()` mirroring `remove_settings_hook()`; "will remove" summary extended.

### On the `SessionStart` matcher shape

Verified against the current hook docs rather than assumed. `SessionStart` matchers key on the session **source** (`startup` / `resume` / `clear` / `compact` / `fork`), and the output envelope is `hookSpecificOutput.additionalContext`. Alternation (`"startup|resume"`) is documented for *tool* matchers but **not** for `SessionStart`, and a matcher that silently matched nothing would leave the hook inert with no error — so install wires **two literal entries** using only documented values. The script re-checks `.source` itself, so a hand-edited `settings.json` routing `clear` here still no-ops.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|---|---|---|
| Reads `SessionStart` stdin JSON (`.cwd`, `.source`), resolves `.claude/handoff.md` from repo root, fails open | ✅ | Cases: subdir cwd, non-git cwd fallback, nonexistent cwd, missing cwd |
| Fires only for `startup`/`resume`; silent no-op for `clear` | ✅ | Cases for `clear`, `compact`, `fork` — all exit 0, no output despite note present |
| Note absent/unreadable → exit 0, no output | ✅ | Cases: no note, `chmod 000` note, `handoff.md` as a directory |
| Emits `hookSpecificOutput` with path, age, staleness ≥7d, headers-only summary | ✅ | Cases assert `hookEventName == "SessionStart"`, path, `just now`/`5h old`/`3d old`/`8d old`, `STALE` at 8d but not 6d, headers 1–9 present, header 10 dropped, body prose absent, `###` not treated as a section |
| Hook is read-only | ✅ | Content `cksum` + mtime asserted unchanged across a run |
| Never exits non-zero, never malformed JSON | ✅ | Empty stdin, `not json at all {{{`, JSON array payload, missing fields — all exit 0, no output; success path asserted valid JSON, exactly one line |
| `install.sh` wires idempotently and coexistence-aware | ✅ | Second install → still exactly 2 entries; foreign `clear` hook and a foreign command *inside our `startup` group* both survive |
| Wired unconditionally, no new prompt, identical under `--yes` | ✅ | Called at the same point as `merge_settings_hook`, before the `--dev` early-exit; no `confirm` added |
| `--dev` symlinks the script; settings wiring runs before the dev-mode branch | ✅ | Uses the shared `install_file()`; verified in code that both merges precede the `--dev` `exit 0` |
| `--dry-run` lists the script + the `SessionStart` wiring line | ✅ | Asserted; also asserted `--dry-run` writes nothing |
| `uninstall.sh` removes the entry, prunes empty containers, leaves unrelated hooks | ✅ | Asserted removal, `.hooks.SessionStart` container pruned when empty, both foreign hooks survive |
| Automated tests for fresh / stale / absent / `clear` / malformed stdin | ✅ | All present |
| Shell-wrapper constraints #1,2,3,5,6,7 out of scope; #4 (stat portability) applies | ✅ | Wrapper not implemented; portable stat implemented and exercised |

## Test Plan

```
$ ./hooks/repo/tests/run.sh                        # exit 0 — PASS: 56  FAIL: 0
    (includes) test-session-start-handoff.sh       -> 79 cases pass
$ ./hooks/repo/tests/test-guard-destructive.sh     # exit 0 — Total: 444  Passed: 444  Failed: 0
```

The pre-existing 444-case guard suite was re-run specifically to confirm the shared `install.sh`/`uninstall.sh` edits did not regress the `PreToolUse` wiring.

Manual end-to-end against a scratch repo: `--dry-run` lists both new lines; `install.sh -y` produces the two matcher entries; a synthetic `{"cwd":...,"source":"startup"}` payload yields well-formed `additionalContext`; `"source":"clear"` yields silence + exit 0; `uninstall.sh -y` reports and removes the entry.

## Out of Scope (deliberate)

The shell `claude` wrapper that edits `~/.zshrc`/`~/.bashrc` is **not** implemented, per the curated scope. Nothing in this PR touches any file outside the target repo. Design constraints #1 (alias parsing), #2 (recursion), #3 (subcommand gating), #5 (fish detection), #6 (rc idempotency markers + rc uninstall) and #7 (rc backup) apply only to that wrapper and remain unaddressed; they belong to a follow-up issue if a human still wants it.

No `CHANGELOG.md` entry: this repo adds those in the `Release vX.Y.Z` commit, not in feature PRs (verified against 7caf5fc and 568daa5).

Closes #32