### PR TITLE
fix(install): anchor CLAUDE.md block rewrites to the marker string, not the line

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,10 @@ commands/repo/*.md           Command files installed to .claude/commands/repo/
 hooks/repo/guard-destructive.sh  PreToolUse guard hook installed to .claude/skills/repo/hooks/
 hooks/repo/tests/run.sh      Quick smoke suite for the guard hook (bash, no framework needed)
 hooks/repo/tests/test-guard-destructive.sh  Full guard regression suite (ported from Loom)
+hooks/repo/tests/test-install-claude-md-markers.sh  CLAUDE.md marker-block regression suite
 install.sh                   Installer
 uninstall.sh                 Uninstaller
+lib/claude-md-block.sh       Marker-bounded CLAUDE.md surgery shared by install.sh/uninstall.sh
 ```
 
 ## Adding a skill

--- a/hooks/repo/tests/run.sh
+++ b/hooks/repo/tests/run.sh
@@ -182,6 +182,26 @@ else
     printf '%s\n' "$SS_OUT" | sed 's/^/    /'
 fi
 
+# install.sh / uninstall.sh CLAUDE.md marker-block surgery (repo#38). Same
+# delegation shape as the handoff suite above: it drives the installers against
+# scratch git repos rather than piping hook payloads, so it shares nothing with
+# expect() and folds in as a single case.
+echo
+echo "-- install/uninstall CLAUDE.md markers (delegated suite) --"
+MD_TEST="$TESTS_DIR/test-install-claude-md-markers.sh"
+if [[ ! -f "$MD_TEST" ]]; then
+    FAIL=$((FAIL + 1))
+    printf '  FAIL %-52s -> not found at %s\n' "test-install-claude-md-markers.sh" "$MD_TEST"
+elif MD_OUT="$(bash "$MD_TEST" 2>&1)"; then
+    PASS=$((PASS + 1))
+    printf '  ok   %-52s -> %s\n' "test-install-claude-md-markers.sh" \
+        "$(printf '%s\n' "$MD_OUT" | awk '/^  Total:/ {print $2 " cases pass"}')"
+else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL %-52s -> suite failed; output follows\n' "test-install-claude-md-markers.sh"
+    printf '%s\n' "$MD_OUT" | sed 's/^/    /'
+fi
+
 echo
 echo "==============================="
 echo "PASS: $PASS   FAIL: $FAIL"

--- a/hooks/repo/tests/test-install-claude-md-markers.sh
+++ b/hooks/repo/tests/test-install-claude-md-markers.sh
@@ -1,0 +1,455 @@
+#!/usr/bin/env bash
+# Regression suite for marker-bounded CLAUDE.md surgery in install.sh /
+# uninstall.sh (lib/claude-md-block.sh).
+#
+# Usage: ./hooks/repo/tests/test-install-claude-md-markers.sh
+# Exit code 0 = all tests pass, 1 = failures detected.
+#
+# Structured like test-guard-destructive.sh / test-session-start-handoff.sh next
+# door: pure bash, no test framework, PASS/FAIL counters and a summary block.
+#
+# The bug under test (repo#38): all three call sites bounded the REPO-SKILLS
+# block with awk whole-line equality, so a CLAUDE.md written as
+#
+#     <!-- END REPO-SKILLS --><!-- BEGIN LOOM ORCHESTRATION -->
+#
+# (no newline between two tools' blocks — what you get when two installers each
+# append without a trailing newline) made the end marker never compare equal,
+# leaving the skip flag set and silently dropping every byte to EOF. An upgrade
+# deleted Loom's entire orchestration block, printed "✓ Updated", and exited 0.
+#
+# The contract asserted below:
+#   - both adjacency orderings survive byte-identical, at all three call sites
+#     (install update path, reconcile_orphaned_block, uninstall)
+#   - the non-adjacent common case is unchanged
+#   - an unresolvable marker layout is refused loudly, leaves CLAUDE.md
+#     untouched, and exits non-zero from install.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+INSTALL_SH="$REPO_ROOT/install.sh"
+UNINSTALL_SH="$REPO_ROOT/uninstall.sh"
+VERSION="$(cat "$REPO_ROOT/VERSION" 2>/dev/null || echo unknown)"
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+for f in "$INSTALL_SH" "$UNINSTALL_SH" "$REPO_ROOT/lib/claude-md-block.sh"; do
+    if [[ ! -f "$f" ]]; then
+        echo "FATAL: required script not found at $f" >&2
+        exit 1
+    fi
+done
+
+SCRATCH="$(cd "$(mktemp -d)" && pwd -P)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+# ---------------------------------------------------------------------------
+# Assertion helpers
+# ---------------------------------------------------------------------------
+
+ok() {   # <label>
+    TOTAL=$((TOTAL + 1)); PASS=$((PASS + 1))
+    printf "  ${GREEN}PASS${NC}: %s\n" "$1"
+}
+no() {   # <label> <detail>
+    TOTAL=$((TOTAL + 1)); FAIL=$((FAIL + 1))
+    printf "  ${RED}FAIL${NC}: %s\n" "$1"
+    [[ -n "${2:-}" ]] && printf "%s\n" "$2" | sed 's/^/        /'
+    return 0
+}
+assert_eq() {  # <label> <expected> <actual>
+    if [[ "$2" == "$3" ]]; then ok "$1"; else no "$1" "expected [$2], got [$3]"; fi
+}
+assert_contains() {  # <label> <haystack> <needle>
+    if [[ "$2" == *"$3"* ]]; then ok "$1"; else no "$1" "missing [$3]"; fi
+}
+assert_not_contains() {  # <label> <haystack> <needle>
+    if [[ "$2" != *"$3"* ]]; then ok "$1"; else no "$1" "unexpectedly present: [$3]"; fi
+}
+# Byte-exact file comparison. Deliberately file-to-file rather than
+# string-to-file: `$(...)` strips trailing newlines, and whether the rewritten
+# CLAUDE.md still ends in one is exactly the kind of byte the fix must preserve.
+assert_bytes() {  # <label> <actual-file> <expected-file>
+    if diff -u "$3" "$2" >/dev/null 2>&1; then
+        ok "$1"
+    else
+        no "$1" "$(diff -u "$3" "$2" | head -25)"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+# Slurp a file for substring assertions. Note that `$(slurp f)` still drops
+# trailing newlines — that is fine for assert_contains/assert_eq, where both
+# sides are stripped alike, but never use it for byte-exactness (assert_bytes
+# compares files directly for exactly that reason).
+slurp() {  # <file>
+    local c
+    c="$(cat "$1"; printf 'X')"
+    printf '%s' "${c%X}"
+}
+
+# Everything from the first occurrence of <needle> to EOF (needle included).
+# Substring-based, not line-based, because in the adjacency fixtures the needle
+# does not start its physical line. Redirect to a file and compare with
+# assert_bytes; the sentinel keeps the trailing newline intact.
+tail_from() {  # <file> <needle> -> stdout
+    local c=""
+    c="$(cat "$1"; printf 'X')"; c="${c%X}"
+    printf '%s%s' "$2" "${c#*"$2"}"
+}
+
+# Everything from the start of the file through <needle> (needle included).
+head_through() {  # <file> <needle> -> stdout
+    local c=""
+    c="$(cat "$1"; printf 'X')"; c="${c%X}"
+    printf '%s%s' "${c%%"$2"*}" "$2"
+}
+
+new_target() {  # <name> -> prints the target path
+    local t="$SCRATCH/$1"
+    mkdir -p "$t"
+    git init -q "$t" 2>/dev/null
+    printf '%s' "$t"
+}
+
+# uninstall.sh bails early unless an install is present; these tests care only
+# about the CLAUDE.md surgery, so fake the directory it looks for.
+fake_installed() {  # <target>
+    mkdir -p "$1/.claude/skills/repo"
+}
+
+# ===========================================================================
+echo "install.sh / uninstall.sh CLAUDE.md marker suite"
+echo "================================================"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "-- install.sh update path: our END adjacent to another tool's BEGIN (repo#38) --"
+
+T1="$(new_target adjacent-after)"
+cat > "$T1/CLAUDE.md" <<'EOF'
+Some intro content.
+
+<!-- BEGIN REPO-SKILLS -->
+OLD repo skills content line 1
+removals. Managed by `install.sh` — edit outside the markers only.
+<!-- END REPO-SKILLS --><!-- BEGIN LOOM ORCHESTRATION -->
+This repository uses Loom for AI-powered development orchestration.
+<!-- END LOOM ORCHESTRATION -->
+
+Trailing prose that must survive.
+EOF
+cat > "$SCRATCH/expected-loom-tail" <<'EOF'
+<!-- BEGIN LOOM ORCHESTRATION -->
+This repository uses Loom for AI-powered development orchestration.
+<!-- END LOOM ORCHESTRATION -->
+
+Trailing prose that must survive.
+EOF
+
+OUT1="$(bash "$INSTALL_SH" -y "$T1" 2>&1)"; RC1=$?
+BODY1="$(slurp "$T1/CLAUDE.md")"
+
+assert_eq        "adjacent-after: install exits 0"                "0" "$RC1"
+tail_from "$T1/CLAUDE.md" '<!-- BEGIN LOOM ORCHESTRATION -->' > "$SCRATCH/actual-loom-tail"
+assert_bytes     "adjacent-after: Loom block + tail byte-identical" \
+                 "$SCRATCH/actual-loom-tail" "$SCRATCH/expected-loom-tail"
+assert_contains  "adjacent-after: content before the block survives" "$BODY1" "Some intro content."
+assert_contains  "adjacent-after: block was refreshed"            "$BODY1" "Repo Skills](https://github.com/rjwalters/repo) v$VERSION"
+assert_not_contains "adjacent-after: stale block body is gone"    "$BODY1" "OLD repo skills content line 1"
+assert_contains  "adjacent-after: adjacency preserved verbatim"   "$BODY1" '<!-- END REPO-SKILLS --><!-- BEGIN LOOM ORCHESTRATION -->'
+assert_contains  "adjacent-after: reports the update"             "$OUT1" "Updated REPO-SKILLS block in CLAUDE.md"
+assert_contains  "adjacent-after: reports a backup snapshot"      "$OUT1" "Backed up CLAUDE.md to "
+
+# Re-running must be a no-op on the neighbour's block (idempotence).
+BEFORE_RERUN="$(slurp "$T1/CLAUDE.md")"
+bash "$INSTALL_SH" -y "$T1" >/dev/null 2>&1
+assert_eq "adjacent-after: re-install is idempotent" "$BEFORE_RERUN" "$(slurp "$T1/CLAUDE.md")"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "-- install.sh update path: another tool's END adjacent to our BEGIN --"
+
+T2="$(new_target adjacent-before)"
+cat > "$T2/CLAUDE.md" <<'EOF'
+Preamble that must survive.
+
+<!-- BEGIN LOOM ORCHESTRATION -->
+This repository uses Loom for AI-powered development orchestration.
+<!-- END LOOM ORCHESTRATION --><!-- BEGIN REPO-SKILLS -->
+OLD repo skills content line 1
+<!-- END REPO-SKILLS -->
+
+Trailing prose that must survive.
+EOF
+# No trailing newline: head_through() stops at the marker itself.
+printf '%s' 'Preamble that must survive.
+
+<!-- BEGIN LOOM ORCHESTRATION -->
+This repository uses Loom for AI-powered development orchestration.
+<!-- END LOOM ORCHESTRATION -->' > "$SCRATCH/expected-loom-head"
+
+OUT2="$(bash "$INSTALL_SH" -y "$T2" 2>&1)"; RC2=$?
+BODY2="$(slurp "$T2/CLAUDE.md")"
+
+assert_eq    "adjacent-before: install exits 0" "0" "$RC2"
+head_through "$T2/CLAUDE.md" '<!-- END LOOM ORCHESTRATION -->' > "$SCRATCH/actual-loom-head"
+assert_bytes "adjacent-before: preceding Loom block byte-identical" \
+             "$SCRATCH/actual-loom-head" "$SCRATCH/expected-loom-head"
+assert_contains     "adjacent-before: block was refreshed"     "$BODY2" "Repo Skills](https://github.com/rjwalters/repo) v$VERSION"
+assert_not_contains "adjacent-before: stale block body is gone" "$BODY2" "OLD repo skills content line 1"
+assert_contains     "adjacent-before: trailing prose survives"  "$BODY2" "Trailing prose that must survive."
+assert_contains     "adjacent-before: reports the update"       "$OUT2"  "Updated REPO-SKILLS block in CLAUDE.md"
+assert_contains     "adjacent-before: adjacency preserved verbatim" "$BODY2" '<!-- END LOOM ORCHESTRATION --><!-- BEGIN REPO-SKILLS -->'
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "-- install.sh append path: no block yet, neighbour has no trailing newline --"
+
+T3="$(new_target append-no-newline)"
+printf '%s' 'Preamble.
+
+<!-- BEGIN LOOM ORCHESTRATION -->
+Loom content.
+<!-- END LOOM ORCHESTRATION -->' > "$T3/CLAUDE.md"
+BEFORE3="$(slurp "$T3/CLAUDE.md")"
+
+OUT3="$(bash "$INSTALL_SH" -y "$T3" 2>&1)"; RC3=$?
+BODY3="$(slurp "$T3/CLAUDE.md")"
+
+assert_eq       "append: install exits 0" "0" "$RC3"
+assert_contains "append: reports the append"     "$OUT3" "Appended REPO-SKILLS block to CLAUDE.md"
+assert_eq       "append: existing content is a byte-identical prefix" \
+                "$BEFORE3" "${BODY3:0:${#BEFORE3}}"
+assert_contains "append: our BEGIN starts its own line" "$BODY3" "$(printf '\n<!-- BEGIN REPO-SKILLS -->')"
+assert_not_contains "append: no adjacency created" "$BODY3" '<!-- END LOOM ORCHESTRATION --><!-- BEGIN REPO-SKILLS -->'
+
+# A second install must take the update path and still leave Loom alone.
+bash "$INSTALL_SH" -y "$T3" >/dev/null 2>&1
+assert_eq "append: re-install keeps neighbour byte-identical" \
+          "$BEFORE3" "$(head_through "$T3/CLAUDE.md" '<!-- END LOOM ORCHESTRATION -->')"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "-- install.sh update path: non-adjacent common case unchanged --"
+
+T4="$(new_target non-adjacent)"
+cat > "$T4/CLAUDE.md" <<'EOF'
+Project notes.
+
+<!-- BEGIN REPO-SKILLS -->
+OLD repo skills content line 1
+<!-- END REPO-SKILLS -->
+
+<!-- BEGIN LOOM ORCHESTRATION -->
+Loom content.
+<!-- END LOOM ORCHESTRATION -->
+EOF
+cat > "$SCRATCH/expected-nonadjacent-tail" <<'EOF'
+<!-- BEGIN LOOM ORCHESTRATION -->
+Loom content.
+<!-- END LOOM ORCHESTRATION -->
+EOF
+
+OUT4="$(bash "$INSTALL_SH" -y "$T4" 2>&1)"; RC4=$?
+BODY4="$(slurp "$T4/CLAUDE.md")"
+
+assert_eq    "non-adjacent: install exits 0" "0" "$RC4"
+tail_from "$T4/CLAUDE.md" '<!-- BEGIN LOOM ORCHESTRATION -->' > "$SCRATCH/actual-nonadjacent-tail"
+assert_bytes "non-adjacent: neighbour block byte-identical" \
+             "$SCRATCH/actual-nonadjacent-tail" "$SCRATCH/expected-nonadjacent-tail"
+assert_contains     "non-adjacent: reports the update"      "$OUT4"  "Updated REPO-SKILLS block in CLAUDE.md"
+assert_contains     "non-adjacent: preamble survives"       "$BODY4" "Project notes."
+assert_contains     "non-adjacent: block was refreshed"     "$BODY4" "Repo Skills](https://github.com/rjwalters/repo) v$VERSION"
+assert_not_contains "non-adjacent: stale block body is gone" "$BODY4" "OLD repo skills content line 1"
+assert_contains     "non-adjacent: markers keep their own lines" "$BODY4" "$(printf '\n<!-- END REPO-SKILLS -->\n')"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "-- uninstall.sh: adjacency and common case --"
+
+T5="$(new_target uninstall-adjacent)"
+fake_installed "$T5"
+cat > "$T5/CLAUDE.md" <<'EOF'
+Some intro content.
+
+<!-- BEGIN REPO-SKILLS -->
+Repo skills pointer body.
+<!-- END REPO-SKILLS --><!-- BEGIN LOOM ORCHESTRATION -->
+This repository uses Loom for AI-powered development orchestration.
+<!-- END LOOM ORCHESTRATION -->
+
+Trailing prose that must survive.
+EOF
+cat > "$SCRATCH/expected-uninstall-adjacent" <<'EOF'
+Some intro content.
+
+<!-- BEGIN LOOM ORCHESTRATION -->
+This repository uses Loom for AI-powered development orchestration.
+<!-- END LOOM ORCHESTRATION -->
+
+Trailing prose that must survive.
+EOF
+
+OUT5="$(bash "$UNINSTALL_SH" -y "$T5" 2>&1)"; RC5=$?
+assert_eq    "uninstall adjacent: exits 0" "0" "$RC5"
+assert_bytes "uninstall adjacent: everything but our block survives byte-identical" \
+             "$T5/CLAUDE.md" "$SCRATCH/expected-uninstall-adjacent"
+assert_contains "uninstall adjacent: reports removal" "$OUT5" "Removed REPO-SKILLS block from CLAUDE.md"
+
+T6="$(new_target uninstall-non-adjacent)"
+fake_installed "$T6"
+cat > "$T6/CLAUDE.md" <<'EOF'
+Project notes.
+
+<!-- BEGIN REPO-SKILLS -->
+Repo skills pointer body.
+<!-- END REPO-SKILLS -->
+
+<!-- BEGIN LOOM ORCHESTRATION -->
+Loom content.
+<!-- END LOOM ORCHESTRATION -->
+EOF
+cat > "$SCRATCH/expected-uninstall-non-adjacent" <<'EOF'
+Project notes.
+
+
+<!-- BEGIN LOOM ORCHESTRATION -->
+Loom content.
+<!-- END LOOM ORCHESTRATION -->
+EOF
+
+bash "$UNINSTALL_SH" -y "$T6" >/dev/null 2>&1
+assert_bytes "uninstall non-adjacent: whole-line removal (historical behavior)" \
+             "$T6/CLAUDE.md" "$SCRATCH/expected-uninstall-non-adjacent"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "-- install.sh reconcile_orphaned_block (gitignored destination) --"
+
+T7="$(new_target reconcile-adjacent)"
+printf '%s\n' '.claude/' > "$T7/.gitignore"
+cat > "$T7/CLAUDE.md" <<'EOF'
+Some intro content.
+
+<!-- BEGIN REPO-SKILLS -->
+Stale pointer body from an earlier install.
+<!-- END REPO-SKILLS --><!-- BEGIN LOOM ORCHESTRATION -->
+This repository uses Loom for AI-powered development orchestration.
+<!-- END LOOM ORCHESTRATION -->
+
+Trailing prose that must survive.
+EOF
+
+OUT7="$(bash "$INSTALL_SH" -y "$T7" 2>&1)"; RC7=$?
+assert_eq    "reconcile adjacent: install exits 0" "0" "$RC7"
+assert_contains "reconcile adjacent: reports orphan removal" "$OUT7" "Removed orphaned REPO-SKILLS block from CLAUDE.md"
+assert_bytes "reconcile adjacent: neighbour + tail survive byte-identical" \
+             "$T7/CLAUDE.md" "$SCRATCH/expected-uninstall-adjacent"
+
+T8="$(new_target reconcile-non-adjacent)"
+printf '%s\n' '.claude/' > "$T8/.gitignore"
+cat > "$T8/CLAUDE.md" <<'EOF'
+Project notes.
+
+<!-- BEGIN REPO-SKILLS -->
+Stale pointer body from an earlier install.
+<!-- END REPO-SKILLS -->
+
+<!-- BEGIN LOOM ORCHESTRATION -->
+Loom content.
+<!-- END LOOM ORCHESTRATION -->
+EOF
+
+bash "$INSTALL_SH" -y "$T8" >/dev/null 2>&1
+assert_bytes "reconcile non-adjacent: whole-line removal (historical behavior)" \
+             "$T8/CLAUDE.md" "$SCRATCH/expected-uninstall-non-adjacent"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "-- guard: unresolvable marker layouts are refused, never guessed --"
+
+T9="$(new_target guard-unterminated)"
+cat > "$T9/CLAUDE.md" <<'EOF'
+Project notes.
+
+<!-- BEGIN REPO-SKILLS -->
+Someone deleted the end marker by hand.
+
+<!-- BEGIN LOOM ORCHESTRATION -->
+Loom content.
+<!-- END LOOM ORCHESTRATION -->
+EOF
+BEFORE9="$(slurp "$T9/CLAUDE.md")"
+
+OUT9="$(bash "$INSTALL_SH" -y "$T9" 2>&1)"; RC9=$?
+assert_eq       "guard unterminated: install exits non-zero" "1" "$RC9"
+assert_contains "guard unterminated: warning names the file" "$OUT9" "$T9/CLAUDE.md"
+assert_contains "guard unterminated: explains the refusal"   "$OUT9" "Refusing to update the REPO-SKILLS block"
+assert_not_contains "guard unterminated: never claims success" "$OUT9" "Updated REPO-SKILLS block in CLAUDE.md"
+assert_eq       "guard unterminated: CLAUDE.md untouched" "$BEFORE9" "$(slurp "$T9/CLAUDE.md")"
+
+T10="$(new_target guard-duplicate)"
+cat > "$T10/CLAUDE.md" <<'EOF'
+Project notes.
+
+<!-- BEGIN REPO-SKILLS -->
+First block.
+<!-- END REPO-SKILLS -->
+
+<!-- BEGIN REPO-SKILLS -->
+Second block from a botched merge.
+<!-- END REPO-SKILLS -->
+EOF
+BEFORE10="$(slurp "$T10/CLAUDE.md")"
+
+OUT10="$(bash "$INSTALL_SH" -y "$T10" 2>&1)"; RC10=$?
+assert_eq       "guard duplicate: install exits non-zero" "1" "$RC10"
+assert_contains "guard duplicate: reports the occurrence count" "$OUT10" "found 2 occurrences"
+assert_eq       "guard duplicate: CLAUDE.md untouched" "$BEFORE10" "$(slurp "$T10/CLAUDE.md")"
+
+T11="$(new_target guard-uninstall)"
+fake_installed "$T11"
+cat > "$T11/CLAUDE.md" <<'EOF'
+Project notes.
+
+<!-- BEGIN REPO-SKILLS -->
+Someone deleted the end marker by hand.
+
+<!-- BEGIN LOOM ORCHESTRATION -->
+Loom content.
+<!-- END LOOM ORCHESTRATION -->
+EOF
+BEFORE11="$(slurp "$T11/CLAUDE.md")"
+
+OUT11="$(bash "$UNINSTALL_SH" -y "$T11" 2>&1)"; RC11=$?
+assert_eq       "guard uninstall: exits 0 (removal skipped, not fatal)" "0" "$RC11"
+assert_contains "guard uninstall: warning names the file" "$OUT11" "$T11/CLAUDE.md"
+assert_not_contains "guard uninstall: never claims removal" "$OUT11" "Removed REPO-SKILLS block from CLAUDE.md"
+assert_eq       "guard uninstall: CLAUDE.md untouched" "$BEFORE11" "$(slurp "$T11/CLAUDE.md")"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "========================================="
+echo "  Total:  $TOTAL"
+printf "  ${GREEN}Passed${NC}: %s\n" "$PASS"
+printf "  ${RED}Failed${NC}: %s\n" "$FAIL"
+echo "========================================="
+
+if [[ $FAIL -gt 0 ]]; then
+    printf "\n${RED}TESTS FAILED${NC}\n"
+    exit 1
+fi
+printf "\n${GREEN}ALL TESTS PASSED${NC}\n"
+exit 0

--- a/install.sh
+++ b/install.sh
@@ -54,6 +54,11 @@ COMMIT="$(git -C "$SOURCE_ROOT" rev-parse --short HEAD 2>/dev/null || echo unkno
 MARKER_BEGIN='<!-- BEGIN REPO-SKILLS -->'
 MARKER_END='<!-- END REPO-SKILLS -->'
 
+# Marker-string-anchored CLAUDE.md surgery, shared with uninstall.sh. Never
+# rewrite the block by hand here — see lib/claude-md-block.sh (repo#38).
+# shellcheck source=lib/claude-md-block.sh
+source "$SOURCE_ROOT/lib/claude-md-block.sh"
+
 claude_md_has_block() { [[ -f "$TARGET/CLAUDE.md" ]] && grep -qF "$MARKER_BEGIN" "$TARGET/CLAUDE.md"; }
 
 # A pointer block committed by an earlier install goes permanently stale once
@@ -72,15 +77,15 @@ reconcile_orphaned_block() {
     return 0
   fi
   if confirm "Remove the orphaned REPO-SKILLS block from CLAUDE.md? [Y/n] " Y; then
-    local tmp
-    tmp="$(mktemp)"
-    awk -v begin="$MARKER_BEGIN" -v end="$MARKER_END" '
-      $0 == begin { skip = 1; next }
-      $0 == end   { skip = 0; next }
-      !skip       { print }
-    ' "$TARGET/CLAUDE.md" >"$tmp"
-    mv "$tmp" "$TARGET/CLAUDE.md"
-    success "Removed orphaned REPO-SKILLS block from CLAUDE.md"
+    if claude_md_block_rewrite "$TARGET/CLAUDE.md" "$MARKER_BEGIN" "$MARKER_END"; then
+      info "Backed up CLAUDE.md to $CLAUDE_MD_BLOCK_BACKUP before rewriting"
+      success "Removed orphaned REPO-SKILLS block from CLAUDE.md"
+    else
+      warning "Refusing to rewrite $TARGET/CLAUDE.md: $CLAUDE_MD_BLOCK_ERROR"
+      warning "The marker layout cannot be resolved unambiguously, and guessing risks"
+      warning "deleting content this installer does not own. CLAUDE.md is untouched."
+      error "Could not safely remove the orphaned REPO-SKILLS block; fix the markers in $TARGET/CLAUDE.md by hand (skills and commands were installed)."
+    fi
   else
     warning "Keeping the stale block. install.sh no longer manages it; update or remove it by hand."
   fi
@@ -508,14 +513,16 @@ BLOCK_FILE="$(mktemp)"
 } >"$BLOCK_FILE"
 
 if [[ -f "$CLAUDE_MD" ]] && grep -qF "$MARKER_BEGIN" "$CLAUDE_MD"; then
-  TMP="$(mktemp)"
-  awk -v begin="$MARKER_BEGIN" -v end="$MARKER_END" -v block="$BLOCK_FILE" '
-    $0 == begin { skip = 1; while ((getline line < block) > 0) print line; close(block); next }
-    $0 == end   { skip = 0; next }
-    !skip       { print }
-  ' "$CLAUDE_MD" >"$TMP"
-  mv "$TMP" "$CLAUDE_MD"
-  success "Updated REPO-SKILLS block in CLAUDE.md"
+  if claude_md_block_rewrite "$CLAUDE_MD" "$MARKER_BEGIN" "$MARKER_END" "$BLOCK_FILE"; then
+    info "Backed up CLAUDE.md to $CLAUDE_MD_BLOCK_BACKUP before rewriting"
+    success "Updated REPO-SKILLS block in CLAUDE.md"
+  else
+    rm -f "$BLOCK_FILE"
+    warning "Refusing to update the REPO-SKILLS block in $CLAUDE_MD: $CLAUDE_MD_BLOCK_ERROR"
+    warning "The marker layout cannot be resolved unambiguously, and guessing risks"
+    warning "deleting content this installer does not own. CLAUDE.md is untouched."
+    error "Could not safely update the REPO-SKILLS block; fix the markers in $CLAUDE_MD by hand (skills and commands were installed)."
+  fi
 else
   { [[ -s "$CLAUDE_MD" ]] && echo ""; cat "$BLOCK_FILE"; } >>"$CLAUDE_MD"
   success "Appended REPO-SKILLS block to CLAUDE.md"

--- a/lib/claude-md-block.sh
+++ b/lib/claude-md-block.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+# Marker-bounded CLAUDE.md surgery, shared by install.sh and uninstall.sh.
+#
+# This file is *sourced*, never executed. Every rewrite of the REPO-SKILLS block
+# in a consumer repo's CLAUDE.md must go through claude_md_block_rewrite() here.
+#
+# Why this exists (repo#38): both installers used to bound the block with awk
+# whole-line equality —
+#
+#     $0 == begin { skip = 1; ... }
+#     $0 == end   { skip = 0; next }
+#     !skip       { print }
+#
+# — which silently destroys data when another tool's block is appended with no
+# intervening newline. The physical line
+#
+#     <!-- END REPO-SKILLS --><!-- BEGIN LOOM ORCHESTRATION -->
+#
+# never compares equal to the end marker, so `skip` never clears and every byte
+# from there to EOF is dropped. That deleted Loom's entire orchestration block
+# in a consumer repo during a routine upgrade, printed "✓ Updated", and exited 0.
+#
+# The replacement below is anchored to the marker *strings*, so text sharing a
+# physical line with a marker is preserved byte-for-byte, and it refuses to
+# touch the file at all when the marker layout cannot be resolved unambiguously
+# (rather than guessing — consuming another tool's content is destructive and
+# must never happen silently).
+#
+# Contract:
+#   claude_md_block_validate <file> <begin> <end>
+#       0 -> the marker boundaries resolve unambiguously
+#       1 -> CLAUDE_MD_BLOCK_ERROR holds a human-readable reason; do not rewrite
+#
+#   claude_md_block_rewrite <file> <begin> <end> [block-file]
+#       Validates, snapshots <file> (path left in CLAUDE_MD_BLOCK_BACKUP), then
+#       replaces the marker span (markers inclusive) with <block-file>'s
+#       contents — or removes the span entirely when <block-file> is omitted.
+#       On failure returns 1 with CLAUDE_MD_BLOCK_ERROR set, having left <file>
+#       byte-for-byte untouched. Callers decide how to report and whether to
+#       abort (install.sh errors out; uninstall.sh warns and skips).
+
+# Set by the functions below; read by callers after a non-zero return. (These
+# are the file's public output channel, so shellcheck's unused-variable warning
+# does not apply — this file is only ever sourced.)
+# shellcheck disable=SC2034
+CLAUDE_MD_BLOCK_ERROR=""
+CLAUDE_MD_BLOCK_BACKUP=""
+
+# Count non-overlapping occurrences of a fixed substring in a file. Markers
+# cannot span lines, so counting per line is exact — and unlike `grep -c` this
+# counts occurrences rather than matching lines, which matters precisely in the
+# adjacency case where two markers share one line.
+_claude_md_count() {  # <file> <needle> -> count on stdout
+  awk -v needle="$2" '
+    {
+      s = $0
+      while ((i = index(s, needle)) > 0) {
+        n++
+        s = substr(s, i + length(needle))
+      }
+    }
+    END { print n + 0 }
+  ' "$1"
+}
+
+# Read a whole file into the global _CLAUDE_MD_SLURPED, preserving trailing
+# newlines exactly. The sentinel byte defeats command substitution's
+# trailing-newline stripping; the result is returned via a variable rather than
+# stdout so a caller's own `$(...)` cannot strip it right back off.
+_CLAUDE_MD_SLURPED=""
+_claude_md_slurp() {  # <file> -> sets _CLAUDE_MD_SLURPED
+  local content
+  content="$(cat "$1"; printf 'X')"
+  _CLAUDE_MD_SLURPED="${content%X}"
+}
+
+claude_md_block_validate() {  # <file> <begin> <end>
+  local file="$1" begin="$2" end="$3" n_begin n_end content prefix
+  CLAUDE_MD_BLOCK_ERROR=""
+
+  if [[ ! -f "$file" ]]; then
+    CLAUDE_MD_BLOCK_ERROR="$file does not exist"
+    return 1
+  fi
+
+  n_begin="$(_claude_md_count "$file" "$begin")"
+  n_end="$(_claude_md_count "$file" "$end")"
+
+  if [[ "$n_begin" -ne 1 ]]; then
+    CLAUDE_MD_BLOCK_ERROR="found $n_begin occurrences of '$begin' (expected exactly 1)"
+    return 1
+  fi
+  if [[ "$n_end" -ne 1 ]]; then
+    CLAUDE_MD_BLOCK_ERROR="found $n_end occurrences of '$end' (expected exactly 1)"
+    return 1
+  fi
+
+  _claude_md_slurp "$file"
+  content="$_CLAUDE_MD_SLURPED"
+  prefix="${content%%"$begin"*}"
+  if [[ "$prefix" == *"$end"* ]]; then
+    CLAUDE_MD_BLOCK_ERROR="'$end' appears before '$begin' (markers are out of order)"
+    return 1
+  fi
+
+  return 0
+}
+
+claude_md_block_rewrite() {  # <file> <begin> <end> [block-file]
+  local file="$1" begin="$2" end="$3" block="${4:-}"
+  local content prefix suffix rest_of_line body backup tmp
+
+  CLAUDE_MD_BLOCK_BACKUP=""
+  claude_md_block_validate "$file" "$begin" "$end" || return 1
+
+  _claude_md_slurp "$file"
+  content="$_CLAUDE_MD_SLURPED"
+  # Everything before the begin marker, and everything after the end marker.
+  # Anything sharing those physical lines with a marker lands in one of these
+  # two halves and survives verbatim — that is the whole point of the fix.
+  prefix="${content%%"$begin"*}"
+  suffix="${content#*"$end"}"
+
+  if [[ -n "$block" ]]; then
+    if [[ ! -f "$block" ]]; then
+      CLAUDE_MD_BLOCK_ERROR="replacement block file $block does not exist"
+      return 1
+    fi
+    # The block file is newline-terminated; the span it replaces ends at the end
+    # marker itself, so drop that one trailing newline to avoid inserting a line
+    # break the original layout did not have.
+    _claude_md_slurp "$block"
+    body="${_CLAUDE_MD_SLURPED%$'\n'}"
+    content="$prefix$body$suffix"
+  else
+    # Removal. When the begin marker started its own line, the newline that
+    # terminated the end marker's line is also part of the block's footprint —
+    # consuming it removes whole lines (the historical behavior) instead of
+    # leaving a blank one behind. When the begin marker shares a line with
+    # earlier text, that same newline is what terminates the surviving line, so
+    # it must stay.
+    if [[ -z "$prefix" || "$prefix" == *$'\n' ]]; then
+      rest_of_line="${suffix%%$'\n'*}"
+      if [[ -z "${rest_of_line//[[:space:]]/}" ]]; then
+        if [[ "$suffix" == *$'\n'* ]]; then
+          suffix="${suffix#*$'\n'}"
+        else
+          suffix=""
+        fi
+      fi
+    fi
+    content="$prefix$suffix"
+  fi
+
+  # Defense in depth: snapshot before touching the file, so even a botched
+  # rewrite is recoverable without git (CLAUDE.md may be gitignored, or the
+  # repo may have no commit yet).
+  if ! backup="$(mktemp "${TMPDIR:-/tmp}/CLAUDE.md.backup.XXXXXX")"; then
+    CLAUDE_MD_BLOCK_ERROR="could not create a backup snapshot"
+    return 1
+  fi
+  if ! cp "$file" "$backup"; then
+    CLAUDE_MD_BLOCK_ERROR="could not write the backup snapshot to $backup"
+    return 1
+  fi
+  CLAUDE_MD_BLOCK_BACKUP="$backup"
+
+  if ! tmp="$(mktemp)"; then
+    CLAUDE_MD_BLOCK_ERROR="could not create a temporary file"
+    return 1
+  fi
+  if ! printf '%s' "$content" >"$tmp"; then
+    rm -f "$tmp"
+    CLAUDE_MD_BLOCK_ERROR="could not write the rewritten CLAUDE.md"
+    return 1
+  fi
+  if ! mv "$tmp" "$file"; then
+    rm -f "$tmp"
+    CLAUDE_MD_BLOCK_ERROR="could not move the rewritten file into place (backup: $backup)"
+    return 1
+  fi
+
+  return 0
+}

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -8,14 +8,23 @@ set -euo pipefail
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 BLUE='\033[0;34m'
+YELLOW='\033[1;33m'
 NC='\033[0m'
 
 error()   { echo -e "${RED}✗ Error: $*${NC}" >&2; exit 1; }
 info()    { echo -e "${BLUE}ℹ $*${NC}"; }
 success() { echo -e "${GREEN}✓ $*${NC}"; }
+warning() { echo -e "${YELLOW}⚠ $*${NC}"; }
+
+SOURCE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 MARKER_BEGIN='<!-- BEGIN REPO-SKILLS -->'
 MARKER_END='<!-- END REPO-SKILLS -->'
+
+# Marker-string-anchored CLAUDE.md surgery, shared with install.sh. Never
+# rewrite the block by hand here — see lib/claude-md-block.sh (repo#38).
+# shellcheck source=lib/claude-md-block.sh
+source "$SOURCE_ROOT/lib/claude-md-block.sh"
 
 # The PreToolUse guard command install.sh wires into .claude/settings.json. The
 # hook *script* lives under .claude/skills/repo/hooks/ and is removed with the
@@ -134,14 +143,15 @@ fi
 rmdir "$TARGET/.claude/skills" "$TARGET/.claude/commands" "$TARGET/.claude" 2>/dev/null || true
 
 if [[ -f "$TARGET/CLAUDE.md" ]] && grep -qF "$MARKER_BEGIN" "$TARGET/CLAUDE.md"; then
-  TMP="$(mktemp)"
-  awk -v begin="$MARKER_BEGIN" -v end="$MARKER_END" '
-    $0 == begin { skip = 1; next }
-    $0 == end   { skip = 0; next }
-    !skip       { print }
-  ' "$TARGET/CLAUDE.md" >"$TMP"
-  mv "$TMP" "$TARGET/CLAUDE.md"
-  success "Removed REPO-SKILLS block from CLAUDE.md"
+  if claude_md_block_rewrite "$TARGET/CLAUDE.md" "$MARKER_BEGIN" "$MARKER_END"; then
+    info "Backed up CLAUDE.md to $CLAUDE_MD_BLOCK_BACKUP before rewriting"
+    success "Removed REPO-SKILLS block from CLAUDE.md"
+  else
+    warning "Refusing to rewrite $TARGET/CLAUDE.md: $CLAUDE_MD_BLOCK_ERROR"
+    warning "The marker layout cannot be resolved unambiguously, and guessing risks"
+    warning "deleting content this uninstaller does not own. CLAUDE.md is untouched —"
+    warning "remove the REPO-SKILLS block by hand."
+  fi
 fi
 
 success "Repo Skills uninstalled"


### PR DESCRIPTION
## Summary

`install.sh` silently deleted an adjacent tool's CLAUDE.md marker block — it destroyed Loom's entire orchestration block in `rjwalters/vibesql` during a routine 0.4.3 → 0.6.1 upgrade, printed `✓ Updated REPO-SKILLS block in CLAUDE.md`, and exited 0.

All three rewrite sites bounded the block with awk whole-line equality (`$0 == begin` / `$0 == end`). When two installers each append without a trailing newline you get

```
<!-- END REPO-SKILLS --><!-- BEGIN LOOM ORCHESTRATION -->
```

on one physical line. That merged line never compares equal to the end marker, so `skip` never clears and every byte through EOF is dropped.

This replaces all three sites with marker-**string**-anchored slicing, refuses to rewrite layouts it cannot resolve, backs up before rewriting, and establishes the first test harness for `install.sh`/`uninstall.sh`.

## Changes

- **`lib/claude-md-block.sh` (new)** — shared, sourced-only helper. `claude_md_block_rewrite()` slices the file on the marker strings, so text sharing a physical line with a marker survives byte-for-byte. Removal still consumes the end marker's trailing newline when the begin marker started its own line, so whole-line removal (the historical behavior) is unchanged for the common case. `claude_md_block_validate()` gates it.
- **`install.sh`** — both sites (update path ~512, `reconcile_orphaned_block` ~77) now call the helper. On an unresolvable layout: loud warning naming the file and the reason, CLAUDE.md untouched, **exit non-zero**.
- **`uninstall.sh`** — same helper (removal mode); on an unresolvable layout it warns and skips the removal without ever printing "Removed".
- **Backup before rewrite** — every rewrite snapshots CLAUDE.md to a temp file first and reports the path (`ℹ Backed up CLAUDE.md to …`). Kept out of the consumer's working tree so no untracked `CLAUDE.md.bak` litter appears.
- **`hooks/repo/tests/test-install-claude-md-markers.sh` (new, 49 cases)** — drives the real installers against scratch git repos; conventions follow `test-guard-destructive.sh` / `test-session-start-handoff.sh` (pure bash, scratch dirs, PASS/FAIL counters).
- **`hooks/repo/tests/run.sh`** — one additive delegation block, matching the handoff-suite pattern, so `pnpm test` covers it.
- **`README.md`** — two lines in the repository-layout block.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Replacement anchored to the marker string at all three sites; line-sharing content preserved byte-for-byte | ✅ | `lib/claude-md-block.sh` used by all three; `assert_bytes` diffs the neighbour block file-to-file (catches even a missing trailing newline) |
| Exact reported adjacency (`END REPO-SKILLS` + `BEGIN LOOM ORCHESTRATION`, one line) leaves the other block byte-identical | ✅ | `adjacent-after:` cases + manual repro: the resulting `git diff` in a scratch consumer repo touches only our block |
| Reverse ordering (`END LOOM` + `BEGIN REPO-SKILLS`) covered | ✅ | `adjacent-before:` cases (update path) and `append:` cases (fresh-append path) |
| `uninstall.sh` against the adjacency fixture: content after the block survives byte-identical | ✅ | `uninstall adjacent:` cases |
| `reconcile_orphaned_block` removal path against the adjacency fixture | ✅ | `reconcile adjacent:` cases (gitignored `.claude/` destination triggers the real code path) |
| Ambiguous layout → clear warning naming the file, declines to rewrite, non-zero exit for install.sh; never a silent success | ✅ | `guard unterminated` / `guard duplicate` / `guard uninstall` cases assert exit status, warning text, absence of the success message, and that CLAUDE.md is byte-unchanged |
| Non-adjacent cases unchanged (install, uninstall, reconcile) | ✅ | `non-adjacent:` cases pin the exact post-removal bytes, locking the historical whole-line behavior |
| Test wired into `pnpm test` | ✅ | `./hooks/repo/tests/run.sh` → `ok test-install-claude-md-markers.sh -> 49 cases pass` |

## Test Plan

```
$ ./hooks/repo/tests/run.sh
  ok   test-session-start-handoff.sh    -> 79 cases pass
  ok   test-install-claude-md-markers.sh -> 49 cases pass
  PASS: 57   FAIL: 0          (exit 0)

$ ./hooks/repo/tests/test-guard-destructive.sh
  Total: 444   Passed: 444   Failed: 0   (exit 0)
```

Negative control: with `install.sh`/`uninstall.sh` stashed back to their pre-fix state (new lib + suite retained), **18 of the 49 cases fail** — the suite genuinely reproduces the bug rather than merely describing it.

Manual verification of the exact scenario from the report (scratch git repo, committed CLAUDE.md with the reported adjacency, `install.sh -y`): the Loom block is untouched and the diff contains only the REPO-SKILLS version bump.

## Notes / out of scope

- A marker string appearing as literal prose inside a code fence is not distinguished from a real marker; it now trips the duplicate-marker guard and is **refused** rather than silently mangled. Fully solving fence-awareness was explicitly out of scope.
- `install.sh` comment wording unrelated to this fix is untouched (#37 owns that).
- Pre-existing shellcheck `SC2094`/`SC2016` findings in `install.sh` / `run.sh` are left alone; no new findings were introduced.

Closes #38