### PR TITLE
docs(install): correct the SessionStart matcher rationale

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -195,11 +195,12 @@ HOOK_CMD="\${CLAUDE_PROJECT_DIR}/${HOOK_INSTALL_REL}"
 # The SessionStart handoff hook, same resolution. Claude Code's SessionStart
 # matchers key on the session SOURCE ("startup" | "resume" | "clear" |
 # "compact" | "fork"), not on a tool name. We wire the two literal sources the
-# hook acts on rather than an alternation like "startup|resume": alternation is
-# documented for tool matchers but NOT for SessionStart, and a matcher that
-# silently matched nothing would leave the hook inert with no error. Two literal
-# entries use only documented values. The hook re-checks .source itself, so this
-# is belt-and-braces rather than a load-bearing filter.
+# hook acts on rather than an alternation like "startup|resume". Alternation
+# would work — SessionStart matchers are split on "|" the same way tool matchers
+# are — but two literal entries state the intent without depending on that
+# shared behavior, and each entry reads unambiguously in a consumer's
+# settings.json. The hook re-checks .source itself, so this is belt-and-braces
+# rather than a load-bearing filter.
 SESSIONSTART_HOOK_INSTALL_REL=".claude/skills/repo/hooks/session-start-handoff.sh"
 SESSIONSTART_HOOK_CMD="\${CLAUDE_PROJECT_DIR}/${SESSIONSTART_HOOK_INSTALL_REL}"
 SESSIONSTART_SOURCES=(startup resume)


### PR DESCRIPTION
## What

`install.sh` wires the SessionStart handoff hook as two literal matcher entries (`startup`, `resume`). The comment explaining that choice was factually wrong:

> alternation is documented for tool matchers but NOT for SessionStart, and a matcher that silently matched nothing would leave the hook inert with no error

Alternation **is** supported — Claude Code's matcher comparator takes the split-on-`|` branch for SessionStart the same way it does for tool matchers, so `"startup|resume"` would have worked. This was established by binary inspection during review of PR #34.

The wiring itself is correct and unchanged. Only the rationale was wrong — and a comment that would talk a future maintainer out of a form that actually works is worse than no comment at all.

## Scope

Comment text only. `SESSIONSTART_SOURCES=(startup resume)` and the jq merge loop are untouched.

## Verification

- **Byte-identical output**: installed into scratch repos from `main` and from this branch; emitted `.claude/settings.json` is identical on both sides (`md5 af1d91a169fe1afae924a2d200061482`). Emitted matchers remain `"startup"`, `"resume"`.
- `./hooks/repo/tests/run.sh` → **PASS: 532 FAIL: 0** (includes the 444-case guard suite and the 31-case branches suite)
- `shellcheck -S warning install.sh` → clean

Closes #37