### PR TITLE
fix: inline handoff note body under size cap in SessionStart hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Every category is configurable per repo (`REPO_GUARD_*`/`REPO_*` env vars or `gu
 
 ## Handoff notes at session start
 
-Installing Repo Skills also wires a **SessionStart hook** (`session-start-handoff.sh`). When `/repo:handoff` has left a note at `.claude/handoff.md`, the hook surfaces it as session context on startup and resume — path, age, a section outline, and a staleness warning once the note passes seven days — so a rolled session opens already knowing what the last one left behind.
+Installing Repo Skills also wires a **SessionStart hook** (`session-start-handoff.sh`). When `/repo:handoff` has left a note at `.claude/handoff.md`, the hook surfaces it as session context on startup and resume — path, age, a staleness warning once the note passes seven days, and the note itself: the full body inlined when it is small (at or under a 10 KB cap), or a header outline plus an oversize warning when it is larger — so a rolled session opens already knowing what the last one left behind.
 
 It is strictly read-only: it never writes or deletes the note (absorbing it and removing it is `/repo:handoff`'s own one-shot contract), it stays silent when no note exists, and it fails open, so a hook error can never block session start. It deliberately does not fire on `/clear`, which is not a process relaunch.
 

--- a/commands/repo/handoff.md
+++ b/commands/repo/handoff.md
@@ -86,8 +86,14 @@ reset actually did — any earlier and it is speculative.
 2. A pointer in the agent's auto-memory index (`MEMORY.md` in the memory
    directory, when one exists): a single line —
    `- Handoff note at .claude/handoff.md — READ FIRST, then delete note + this line.`
-   The memory index is read automatically at session start; the pointer is
-   what makes the repo file reliably found rather than merely present.
+   The memory index is read automatically at session start, but it arrives as
+   passive background context, not an instruction — so the pointer is a
+   *best-effort backup*, not a guarantee the note is read (a live handoff has
+   been observed to slip past it). The mechanism that actively announces the
+   note is the `session-start-handoff.sh` **SessionStart hook** (installed by
+   Repo Skills), which surfaces the note as session context on startup and
+   resume — the full body inlined when the note is small, a header outline plus
+   an oversize warning when it is large.
 
 **What goes in — only what is not recoverable from the repo:**
 
@@ -127,7 +133,8 @@ to. End by printing an exact, copy-pasteable block for the human, e.g.:
 claude update
 #   3. Relaunch in this repo:
 cd <repo-root> && claude
-# The new session will find the handoff note via its memory index.
+# The SessionStart hook announces the handoff note to the new session
+# (the memory-index pointer is a best-effort backup).
 ```
 
 Then stop. The ritual is complete when the note is durable and the

--- a/hooks/repo/session-start-handoff.sh
+++ b/hooks/repo/session-start-handoff.sh
@@ -54,9 +54,15 @@
 RECENT_HOURS=48
 STALE_HOURS=168
 
-# Max section headers rendered. The real-world note that motivated this was
-# 7.5 KB - far too much to inject on every launch - but its headers convey the
-# shape in a handful of lines.
+# Payload sizing (issue #33). When the note is small enough (<= MAX_BODY_BYTES)
+# it is cheap to inline verbatim on every launch, and the full body is what
+# carries the actionable content - a headers-only outline conveys shape but
+# nothing to act on. Above that cap we fall back to a headers-only outline
+# (capped at MAX_HEADERS) plus a loud oversize warning, bounding the pathological
+# case. The 10 KB cap comfortably covers the ~9 KB real-world note that motivated
+# the hook, and /repo:handoff's exclusion discipline is designed to keep notes
+# short, so the common case inlines.
+MAX_BODY_BYTES=10240
 MAX_HEADERS=9
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd 2>/dev/null || echo ".")"
@@ -126,11 +132,6 @@ elif (( AGE_H < RECENT_HOURS ));  then AGE_LABEL="${AGE_H}h old"
 else                                   AGE_LABEL="$(( AGE_H / 24 ))d old"
 fi
 
-# Headers only - never the file body. `|| true` because grep exits 1 when the
-# note has no headers at all (a valid, non-error state) and head closing the
-# pipe early can surface as a non-zero status.
-HEADERS=$(grep -E '^#{1,2} ' "$NOTE" 2>/dev/null | head -n "$MAX_HEADERS" | sed 's/^#* *//' || true)
-
 CONTEXT="A /repo:handoff note is pending in this repository.
 
   Path: $NOTE
@@ -142,11 +143,41 @@ if (( AGE_H >= STALE_HOURS )); then
          every claim in it against the repo before acting on it."
 fi
 
-if [[ -n "$HEADERS" ]]; then
+# Payload policy (issue #33). Under the size cap, inline the full note body -
+# that is where the load-bearing, actionable content lives; a headers-only
+# outline conveys shape but nothing to act on, which was the observed failure.
+# Above the cap, fall back to that outline plus an explicit oversize warning so a
+# pathological note cannot bloat every launch. The read-in-full / one-shot
+# directive below is appended in BOTH branches.
+NOTE_BYTES=$(wc -c < "$NOTE" 2>/dev/null | tr -d '[:space:]') || NOTE_BYTES=""
+[[ "$NOTE_BYTES" =~ ^[0-9]+$ ]] || NOTE_BYTES=0
+
+if (( NOTE_BYTES <= MAX_BODY_BYTES )); then
+    # Full body inline. `|| BODY=""` keeps a read failure on the fail-open path.
+    BODY=$(cat "$NOTE" 2>/dev/null) || BODY=""
     CONTEXT="$CONTEXT
+
+The full note follows between the markers - read it now:
+
+----- BEGIN HANDOFF NOTE -----
+$BODY
+----- END HANDOFF NOTE -----"
+else
+    # Oversize fallback: headers only. `|| true` because grep exits 1 when the
+    # note has no headers at all (a valid, non-error state) and head closing the
+    # pipe early can surface as a non-zero status.
+    HEADERS=$(grep -E '^#{1,2} ' "$NOTE" 2>/dev/null | head -n "$MAX_HEADERS" | sed 's/^#* *//' || true)
+    CONTEXT="$CONTEXT
+  OVERSIZE: this note is ${NOTE_BYTES} bytes, above the ${MAX_BODY_BYTES}-byte
+            inline cap, so only its section headers are shown below. Open the
+            note and read it in full now - the actionable detail is in the body,
+            not these headers."
+    if [[ -n "$HEADERS" ]]; then
+        CONTEXT="$CONTEXT
 
 Sections:
 $(printf '%s\n' "$HEADERS" | sed 's/^/  - /')"
+    fi
 fi
 
 CONTEXT="$CONTEXT

--- a/hooks/repo/tests/test-session-start-handoff.sh
+++ b/hooks/repo/tests/test-session-start-handoff.sh
@@ -13,8 +13,9 @@
 # The contract under test (see the hook's header):
 #   - fires only for source "startup"/"resume"
 #   - emits hookSpecificOutput.hookEventName == "SessionStart" with
-#     additionalContext summarizing .claude/handoff.md (path, age, staleness,
-#     section headers only)
+#     additionalContext describing .claude/handoff.md (path, age, staleness) and
+#     the note payload: the full body inlined at/under the size cap, a
+#     headers-only outline plus an oversize warning above it (issue #33)
 #   - never exits non-zero, never emits malformed JSON, never writes the note
 
 set -uo pipefail
@@ -109,7 +110,7 @@ make_repo() {  # <name> -> echoes path
 
 NOTE_BODY='# Handoff — 2026-07-27
 
-Prose that must never be injected wholesale.
+Prose that is inlined verbatim when the note is under the size cap.
 
 ## 1. In-flight — resolve before anything else
 
@@ -148,7 +149,7 @@ assert_contains  "startup: context names the note path"   "$CTX" "$FRESH/.claude
 assert_contains  "startup: context reports age"           "$CTX" "just now"
 assert_contains  "startup: renders a section header"      "$CTX" "1. In-flight — resolve before anything else"
 assert_contains  "startup: renders the title header"      "$CTX" "Handoff — 2026-07-27"
-assert_not_contains "startup: omits note body prose"      "$CTX" "PR #41 awaits review"
+assert_contains  "startup: inlines note body prose"       "$CTX" "PR #41 awaits review"
 assert_not_contains "startup: fresh note is not stale"    "$CTX" "STALE"
 # Exactly one JSON object on stdout (a second would corrupt the hook protocol).
 LINES=$(printf '%s' "$HOOK_OUT" | grep -c . || true)
@@ -208,33 +209,110 @@ assert_not_contains "6d old: below the stale threshold"   "$CTX" "STALE"
 
 # ---------------------------------------------------------------------------
 echo ""
-echo "-- header rendering is capped and headers-only --"
+echo "-- oversize fallback: header outline is capped and headers-only --"
 # ---------------------------------------------------------------------------
+# This note must exceed MAX_BODY_BYTES (10 KB) so the hook takes the headers-only
+# fallback; each section is padded to push the whole note past the cap.
 MANY="$(make_repo many)"
 {
     for i in 1 2 3 4 5 6 7 8 9 10 11 12; do
         echo "## Section $i"
         echo "body-line-$i should never be injected"
+        for _ in $(seq 1 20); do
+            echo "padding padding padding padding padding padding padding padding"
+        done
         echo ""
     done
     echo "### Deep heading level three"
 } > "$MANY/.claude/handoff.md"
 run_hook "$MANY" startup
 CTX=$(printf '%s' "$HOOK_OUT" | jq -r '.hookSpecificOutput.additionalContext // ""' 2>/dev/null)
+assert_contains     "cap: oversize note warns it is too large" "$CTX" "OVERSIZE"
 assert_contains     "cap: first header rendered"          "$CTX" "Section 1"
 assert_contains     "cap: ninth header rendered"          "$CTX" "Section 9"
 assert_not_contains "cap: tenth header dropped"           "$CTX" "Section 10"
 assert_not_contains "cap: body lines never injected"      "$CTX" "body-line-1 should never be injected"
 assert_not_contains "cap: h3 headings not treated as sections" "$CTX" "Deep heading level three"
 
-# A note with no headers at all is still announced (path + age), no crash.
+# A note with no headers at all is still announced (path + age), and since it is
+# small it is inlined verbatim.
 NOHDR="$(make_repo nohdr)"
 printf 'just some prose, no headings at all\n' > "$NOHDR/.claude/handoff.md"
 run_hook "$NOHDR" startup
 assert_eq        "no headers: exit 0"                     "0" "$HOOK_EXIT"
 CTX=$(printf '%s' "$HOOK_OUT" | jq -r '.hookSpecificOutput.additionalContext // ""' 2>/dev/null)
 assert_contains  "no headers: still announces the note"   "$CTX" "$NOHDR/.claude/handoff.md"
-assert_not_contains "no headers: prose not injected"      "$CTX" "just some prose"
+assert_contains  "no headers: inlines the prose body"     "$CTX" "just some prose"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "-- payload policy: capped body inline vs oversize fallback (issue #33) --"
+# ---------------------------------------------------------------------------
+# Under the cap: the FULL body is inlined verbatim, wrapped in markers, with no
+# oversize warning and the read-in-full directive present.
+UNDER="$(make_repo under)"
+printf '%s' "$NOTE_BODY" > "$UNDER/.claude/handoff.md"
+run_hook "$UNDER" startup
+CTX=$(printf '%s' "$HOOK_OUT" | jq -r '.hookSpecificOutput.additionalContext // ""' 2>/dev/null)
+assert_contains  "under cap: inlines full body prose"     "$CTX" "PR #41 awaits review"
+assert_contains  "under cap: inlines the next-action line" "$CTX" "Run the test suite."
+assert_contains  "under cap: wraps body in a begin marker" "$CTX" "BEGIN HANDOFF NOTE"
+assert_contains  "under cap: wraps body in an end marker"  "$CTX" "END HANDOFF NOTE"
+assert_not_contains "under cap: no oversize warning"      "$CTX" "OVERSIZE"
+assert_contains  "under cap: directive present"           "$CTX" "Read the note in full before doing anything else"
+
+# Over the cap: headers outline + oversize warning; body omitted, no markers, but
+# the read-in-full / one-shot directive is still present (BOTH branches carry it).
+OVER="$(make_repo over)"
+{
+    echo "# Oversize handoff"
+    echo "## First real section"
+    echo "load-bearing-sentence-in-the-body"
+    for _ in $(seq 1 220); do
+        echo "filler filler filler filler filler filler filler filler"
+    done
+} > "$OVER/.claude/handoff.md"
+run_hook "$OVER" startup
+assert_eq        "over cap: exit 0"                       "0" "$HOOK_EXIT"
+CTX=$(printf '%s' "$HOOK_OUT" | jq -r '.hookSpecificOutput.additionalContext // ""' 2>/dev/null)
+assert_contains  "over cap: emits oversize warning"       "$CTX" "OVERSIZE"
+assert_contains  "over cap: renders a header outline"     "$CTX" "First real section"
+assert_not_contains "over cap: omits the note body"       "$CTX" "load-bearing-sentence-in-the-body"
+assert_not_contains "over cap: no inline body markers"    "$CTX" "BEGIN HANDOFF NOTE"
+assert_contains  "over cap: directive present"            "$CTX" "Read the note in full before doing anything else"
+assert_contains  "over cap: one-shot delete directive"    "$CTX" "delete both the note and its pointer"
+
+# Boundary: a note of EXACTLY MAX_BODY_BYTES (10240) inlines (condition is <=).
+BND="$(make_repo boundary)"
+BOUND_FILE="$BND/.claude/handoff.md"
+printf '# Boundary note\nunique-boundary-sentinel\n' > "$BOUND_FILE"
+cur=$(wc -c < "$BOUND_FILE" | tr -d '[:space:]')
+pad=$((10240 - cur))
+if (( pad > 0 )); then
+    head -c "$pad" /dev/zero | tr '\0' 'x' >> "$BOUND_FILE"
+fi
+EXACT_BYTES=$(wc -c < "$BOUND_FILE" | tr -d '[:space:]')
+assert_eq        "boundary: note is exactly 10240 bytes"  "10240" "$EXACT_BYTES"
+run_hook "$BND" startup
+CTX=$(printf '%s' "$HOOK_OUT" | jq -r '.hookSpecificOutput.additionalContext // ""' 2>/dev/null)
+assert_contains  "boundary: exactly-cap note is inlined"  "$CTX" "unique-boundary-sentinel"
+assert_not_contains "boundary: exactly-cap not oversize"  "$CTX" "OVERSIZE"
+
+# One byte over the cap flips to the oversize fallback.
+OVER1="$(make_repo boundary_over)"
+OVER1_FILE="$OVER1/.claude/handoff.md"
+printf '# Boundary note\n## Over by one\nunique-over-sentinel\n' > "$OVER1_FILE"
+cur=$(wc -c < "$OVER1_FILE" | tr -d '[:space:]')
+pad=$((10241 - cur))
+if (( pad > 0 )); then
+    head -c "$pad" /dev/zero | tr '\0' 'x' >> "$OVER1_FILE"
+fi
+EXACT_BYTES=$(wc -c < "$OVER1_FILE" | tr -d '[:space:]')
+assert_eq        "boundary+1: note is exactly 10241 bytes" "10241" "$EXACT_BYTES"
+run_hook "$OVER1" startup
+CTX=$(printf '%s' "$HOOK_OUT" | jq -r '.hookSpecificOutput.additionalContext // ""' 2>/dev/null)
+assert_contains  "boundary+1: one byte over falls back"   "$CTX" "OVERSIZE"
+assert_not_contains "boundary+1: body omitted over cap"   "$CTX" "unique-over-sentinel"
 
 # ---------------------------------------------------------------------------
 echo ""

--- a/skills/repo/SKILL.md
+++ b/skills/repo/SKILL.md
@@ -142,9 +142,12 @@ The installer wires a second hook, `session-start-handoff.sh`, as two
 `SessionStart` entries — one matching `startup`, one matching `resume`. When
 [[handoff]] has left a note at `.claude/handoff.md`, the hook emits it as
 session context via `hookSpecificOutput.additionalContext`: the note's path,
-its age, an outline built from its `#`/`##` headers, and a staleness warning
-once the note passes seven days. It renders headers only, never the full body —
-a real handoff note runs to several KB, far too much to inject on every launch.
+its age, a staleness warning once the note passes seven days, and the note
+itself. When the note is at or under a size cap (`MAX_BODY_BYTES`, 10 KB) the
+**full body is inlined**; above the cap it falls back to an outline built from
+the note's `#`/`##` headers plus an explicit oversize warning. Inlining the body
+is deliberate (issue #33): the load-bearing content lives in the body, and a
+headers-only summary conveys shape but nothing actionable.
 
 Behavioral contract:
 


### PR DESCRIPTION
## Summary

The `session-start-handoff.sh` SessionStart hook previously surfaced only a headers-only outline of a pending `/repo:handoff` note. As issue #33 documented from a live miss, headers convey shape but nothing actionable — the load-bearing content lives in the note body — so a handoff could slip past a new session silently. This PR makes the hook inline the note body when it is small, corrects the docs that overstated the memory-index pointer, and extends the test suite.

## Changes

- **`hooks/repo/session-start-handoff.sh`** — new `MAX_BODY_BYTES=10240` cap. When the note is `<=` the cap, the **full body** is inlined between `----- BEGIN/END HANDOFF NOTE -----` markers. Above the cap, it falls back to the existing capped (`MAX_HEADERS=9`) header outline plus an explicit `OVERSIZE` warning. The read-in-full / one-shot-delete directive is appended in **both** branches. Stable interface preserved: silence + exit 0 when nothing to surface, always exit 0, exactly one JSON object on stdout, read-only, `startup`/`resume` source gating.
- **`commands/repo/handoff.md`** — the two overstating passages (`:86-90`, `:130`) no longer claim the pointer makes the note "reliably found." The pointer is now described as a best-effort backup (passive background context), and the SessionStart hook is named as the mechanism that actively announces the note.
- **`skills/repo/SKILL.md`** — hook description no longer says "headers only, never the full body"; now describes the capped-body behavior.
- **`README.md`** — hook section updated to describe full-body inline under the cap, header outline + oversize warning above it.
- **`hooks/repo/tests/test-session-start-handoff.sh`** — new payload-policy cases (body inlined under cap, headers fallback over cap, exact-cap boundary at 10240 and one byte over, directive present in both branches); reworked the former "headers-only" cases now that small notes inline in full.

## Acceptance Criteria Verification

- [x] `handoff.md` no longer claims the pointer makes the note "reliably found" — both cited passages corrected; SessionStart hook named as announcer, pointer as best-effort backup.
- [x] Hook inlines the full body at/under the cap and falls back to headers + oversize warning above it; read-in-full/one-shot directive present in both branches.
- [x] Stable interface preserved (silence + exit 0, always exit 0, one JSON object, read-only, `startup`/`resume` gating) — existing interface tests still green.
- [x] `SKILL.md` and README no longer say "headers only, never the full body" — both describe capped-body behavior.
- [x] Handoff test suite passes with new payload-policy coverage.

## Test Plan

- `pnpm test` → the delegated `session-start-handoff.sh` suite passes **99/99** (up from 79; new payload-policy cases added).
- Pre-existing note: `test-guard-destructive.sh` reports 8 `forceScope` failures on the base branch. That file is **not** touched by this PR (`git diff --name-only` confirms) — the failures are pre-existing and unrelated.

Closes #33