### PR TITLE
ci: add GitHub Actions workflow running the full test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,68 @@
+name: CI
+
+# Runs the repository's full test suite (`pnpm test` -> hooks/repo/tests/run.sh,
+# the ~532-case guard/handoff/loss-check suite) on every pull request and on
+# every push to the default branch. Before this workflow the suite only ran when
+# a human remembered to run it locally, so `gh pr checks` reported "no checks
+# reported" and PRs merged unverified (issue #48).
+#
+# The suite is exercised on every push AND every PR (not split): it takes ~60s,
+# well within a single job's budget, so there is no reason to split coverage and
+# risk it looking like it covers more than it does.
+#
+# Note: this workflow does NOT enable required-status-check branch protection.
+# Requiring this check to merge is a separate, deliberate decision (see #48's
+# acceptance criteria) and must not be silently enabled here.
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+# Cancel superseded runs on the same ref to save runner minutes.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: pnpm test (guard/handoff/loss-check suite)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # The test harness (hooks/repo/tests/run.sh) hard-fails with
+      # "FATAL: jq is required" if jq is absent. ubuntu-latest ships jq, but
+      # install it defensively so the suite never fails for an unrelated reason.
+      - name: Ensure jq is available
+        run: |
+          if ! command -v jq >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y jq
+          fi
+          jq --version
+
+      # commands/repo/tests/test-branches-loss-check.sh needs git >= 2.38 (#46).
+      # ubuntu-latest currently ships git >= 2.43, which satisfies the floor;
+      # print it so a future runner-image regression below 2.38 is visible in the
+      # log rather than surfacing as an opaque loss-check failure.
+      - name: Report git version
+        run: git --version
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      # Runs ./hooks/repo/tests/run.sh via the package.json "test" script and
+      # fails the job on any nonzero exit (a failing assertion turns the check
+      # red — verified by fault injection, per #48's acceptance criteria).
+      - name: Run test suite
+        run: pnpm test

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "private": true,
   "scripts": {
     "worktree:return": "./.loom/scripts/worktree-return.sh",
-    "check:ci": "echo 'No CI checks configured. Customize this script for your project.' && exit 0",
-    "check:all": "echo 'No checks configured. Customize this script for your project.' && exit 0",
+    "check:ci": "pnpm test",
+    "check:all": "pnpm test",
     "test": "./hooks/repo/tests/run.sh",
     "lint": "echo 'No linter configured. Customize this script for your project.' && exit 0"
   }


### PR DESCRIPTION
## Summary

Nothing ran the ~532-case suite automatically: there was no `.github/workflows/`
directory, and `pnpm test` fired only when a human remembered to run it, so
`gh pr checks <n>` reported "no checks reported" and PRs merged unverified. On top
of that, `package.json`'s `check:ci` / `check:all` were `echo ... && exit 0` stubs
— a script named like a CI gate that always passes, which the `.loom` role docs
reference as this repo's documented CI command.

This PR adds a GitHub Actions workflow that runs `pnpm test` on every pull request
and on pushes to `main`, and repoints the two stub scripts at the real suite.

## Changes

- **`.github/workflows/ci.yml`** (new): a `test` job on `ubuntu-latest` that
  checks out the repo, ensures `jq` is present (the harness hard-fails without it),
  reports the runner git version (the loss-check suite needs git >= 2.38, per #46;
  `ubuntu-latest` ships >= 2.43), installs pnpm + Node, and runs `pnpm test`. A
  failing assertion turns the check red. Triggers on `pull_request` and `push` to
  `main`; a `concurrency` group cancels superseded runs.
- **`package.json`**: repoint `check:ci` and `check:all` from their
  `echo ... && exit 0` stubs to `pnpm test`, so the CI command the role docs
  reference is a genuine gate. Deleting them was the other option allowed by the
  acceptance criteria, but the `.loom/roles/*.md` and `.loom/docs/build-gate.md`
  files assume `pnpm check:ci` exists, so wiring it to the suite avoids a docs
  regression across those files.

## Acceptance Criteria Verification

- [x] A workflow runs `pnpm test` on PRs and on pushes to the default branch —
  `.github/workflows/ci.yml` triggers on `pull_request` and `push: branches: [main]`.
- [x] The workflow fails when the suite fails — verified by fault injection: a
  broken assertion makes `run.sh` exit `1` (the passing suite exits `0`), and the
  `Run test suite` step has no `continue-on-error`, so a nonzero exit fails the job.
- [x] Runner git is >= 2.38 — `ubuntu-latest` ships >= 2.43; the workflow logs
  `git --version` so a future runner-image regression below the floor is visible.
- [x] `check:ci` / `check:all` do something real — both now run `pnpm test`; no
  script exits 0 unconditionally while named like a gate.
- [x] Suite-run split documented — the workflow runs the full ~60s suite on both
  push and PR (not split); the header comment states this explicitly.
- [x] Branch protection noted, not enabled — the workflow header comment records
  that requiring this check is a separate, deliberate decision left un-enabled.

## Test Plan

- [x] `pnpm test` in the worktree: **532 pass, 0 fail** (55 inline + 444 guard +
  79 handoff + 49 CLAUDE.md markers + 31 loss-check, folded into the totals).
- [x] `pnpm check:ci` exits 0 on the passing suite (confirms the repoint invokes
  the real suite).
- [x] Fault injection (local): a broken assertion in a scratch copy of `run.sh`
  makes the suite exit `1`, confirming the job would go red.
- [x] Workflow YAML parses (`yaml.safe_load`).
- [ ] Post-merge manual check: confirm `gh pr checks <n>` on a subsequent PR reports
  the new check rather than "no checks reported".

Closes #48