### PR TITLE
feat(remote): add headless repo-remote provisioning script

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ The installer is designed to coexist with whatever already lives in the consumer
 - `.claude/skills/repo/` — the domain skill file plus install metadata
 - `.claude/skills/repo/hooks/guard-destructive.sh` — the PreToolUse guard hook (colocated under the skill dir; removed with it on uninstall)
 - `.claude/skills/repo/hooks/session-start-handoff.sh` — the SessionStart handoff-note hook (same colocation, same uninstall behavior)
+- `.claude/skills/repo/scripts/repo-remote.sh` — the headless provisioning entry point for `/repo:remote` (the interactive skill delegates to it; a caller such as loom's `fleet add-worker` invokes it directly). Same colocation, removed with the skill dir on uninstall
 - `.claude/commands/repo/` — one file per command, namespaced under `repo/` so nothing else is touched
 - `.claude/settings.json` — a single `PreToolUse` → `Bash` hook entry is **merged in** (never wholesale-copied): existing hooks, permissions, and unrelated entries are preserved, re-installs don't duplicate, and if another guard is already wired the installer defers instead. `uninstall.sh` removes only the entry it owns and prunes empty containers
 - `.claude/settings.json` — two `SessionStart` entries (`startup` and `resume`) are merged the same way for the handoff-note hook. A pre-existing `SessionStart` hook from another tool is preserved rather than clobbered, and uninstall removes only the two entries it owns
@@ -86,12 +87,15 @@ Nothing else in the target repository is read or modified.
 ```
 skills/repo/SKILL.md         Domain overview installed to .claude/skills/repo/
 commands/repo/*.md           Command files installed to .claude/commands/repo/
+scripts/repo/repo-remote.sh  Headless /repo:remote provisioning entry point, installed to .claude/skills/repo/scripts/
 hooks/repo/guard-destructive.sh  PreToolUse guard hook installed to .claude/skills/repo/hooks/
 hooks/repo/session-start-handoff.sh  SessionStart handoff-note hook installed to the same place
 hooks/repo/tests/run.sh      Smoke suite covering both hooks (bash, no framework needed)
 hooks/repo/tests/test-guard-destructive.sh  Full guard regression suite (ported from Loom)
 hooks/repo/tests/test-session-start-handoff.sh  Handoff-hook suite (run.sh delegates to it)
 hooks/repo/tests/test-install-claude-md-markers.sh  CLAUDE.md marker-block regression suite
+commands/repo/tests/test-branches-loss-check.sh  branches.md permanent-loss check suite (run.sh delegates)
+commands/repo/tests/test-repo-remote.sh  repo-remote.sh provisioning-contract suite (run.sh delegates)
 install.sh                   Installer
 uninstall.sh                 Uninstaller
 lib/claude-md-block.sh       Marker-bounded CLAUDE.md surgery shared by install.sh/uninstall.sh

--- a/commands/repo/remote.md
+++ b/commands/repo/remote.md
@@ -33,6 +33,29 @@ locally to drive the cloud CLI; they are **never** copied to the VM.
 First time in a repo? Run `/repo:remote --configure` to build the `.env` below,
 then `/repo:remote` to launch.
 
+The provisioning contract below is implemented **once**, as an executable
+script — `scripts/repo/repo-remote.sh`, installed to
+`.claude/skills/repo/scripts/repo-remote.sh`. The interactive flow here is a
+thin wrapper: it runs the wizard/cost-confirmation UX, and once you say yes it
+calls that script rather than re-issuing `aws`/`gcloud` calls from prose. The
+same script is the **headless entry point** a non-interactive caller (e.g.
+loom's `fleet add-worker`) invokes directly:
+
+```
+repo-remote up [aws|gcp]              # DRY RUN: print the resolved plan + estimated cost as JSON, create NOTHING
+repo-remote up --yes [--json]        # provision (or reuse) with no prompts; requires pre-supplied cost-relevant config
+repo-remote status [--json]          # list instances tagged repo-remote=<name>
+repo-remote down [--yes] [--delete]  # dry-run listing without --yes; stop (or --delete to terminate) with --yes
+```
+
+`--yes` **removes the prompt, not the consent.** A cost-relevant field missing
+from config — the provider, its credentials, or `REPO_REMOTE_INSTANCE_TYPE` —
+is a loud, non-zero-exit failure, never a silent default that could pick a
+billable size on its own. Plain `repo-remote up` (no `--yes`) is a dry run that
+prints the plan and estimated hourly cost and spends nothing, so a caller can
+implement a "plan shown before money is spent" check against the `--json`
+output (instance id, public IP, SSH alias, estimated hourly cost).
+
 ## Configuration — two layers
 
 Settings come from two files, loaded in order so the repo can override the
@@ -188,6 +211,15 @@ wants a repo-specific account/region.
 9. Offer to run `/repo:remote` right away.
 
 ## Steps
+
+Steps 1–4, plus `--status`/`--down`, describe the provisioning contract that
+`scripts/repo/repo-remote.sh` implements. The interactive flow **delegates** to
+that script: it performs the credential-hygiene checks and the wizard/cost
+confirmation here, then hands the resolved plan to `repo-remote up --yes`
+(passing the confirmed provider/instance-type through config) rather than
+issuing the `aws`/`gcloud` calls itself. This keeps a single implementation, so
+the headless path and the interactive path cannot drift. The cloud-CLI
+specifics below document *what the script does* and remain the reference for it.
 
 ### 1. Load and validate config
 
@@ -444,6 +476,12 @@ hourly cost estimate, idle-shutdown window, the SSH alias, whether the ID was
 written back to `.env`, and the teardown command (`/repo:remote --down`).
 
 ## `--status` and `--down`
+
+Both delegate to the shared script (`repo-remote status` / `repo-remote down`),
+which resolves the same two config layers and only ever touches instances
+carrying this repo's `repo-remote` tag. `repo-remote down` without `--yes` is a
+dry run that lists exactly what would stop; `--yes` acts, and `--delete`
+terminates.
 
 - `--status`: list all instances labeled `repo-remote=<repo-name>` with state
   and uptime; estimate accumulated cost. Uses the resolved credentials (shared

--- a/commands/repo/tests/test-repo-remote.sh
+++ b/commands/repo/tests/test-repo-remote.sh
@@ -1,0 +1,381 @@
+#!/usr/bin/env bash
+# Test suite for scripts/repo/repo-remote.sh — the headless, scriptable
+# provisioning entry point documented (as prose) in commands/repo/remote.md and
+# consumed by loom's `fleet add-worker` (repo#52).
+#
+# Usage: ./commands/repo/tests/test-repo-remote.sh
+# Exit code 0 = all tests pass, 1 = failures detected.
+#
+# Structured like commands/repo/tests/test-branches-loss-check.sh: pure bash, no
+# framework, PASS/FAIL/TOTAL counters and a summary block. `pnpm test` delegates
+# to this file via hooks/repo/tests/run.sh.
+#
+# WHY THIS FILE EXISTS (repo#52): remote.md is prose an agent reads; the script
+# under test is the executable extraction of its provisioning contract. The two
+# things this suite pins down are the two things that can cost real money if
+# wrong:
+#   1. the cost gate — `up` (with or without --yes) must fail LOUDLY (exit 2)
+#      when a cost-relevant field (provider, credentials, instance type) is
+#      missing from config, never silently substitute a default;
+#   2. config-layer precedence — repo `.env` overrides the shared remote.env.
+# It also covers JSON output shape, GPU detection/cost, the idle-shutdown guard,
+# instance-id write-back, and the end-to-end up/status/down flow against a mock
+# `aws` CLI. A doc-drift block at the end asserts remote.md still documents the
+# subcommands/flags the script implements.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+RR="$REPO_ROOT/scripts/repo/repo-remote.sh"
+REMOTE_MD="$REPO_ROOT/commands/repo/remote.md"
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+if [[ ! -f "$RR" ]]; then
+    echo "FATAL: repo-remote.sh not found at $RR" >&2
+    exit 1
+fi
+if [[ ! -f "$REMOTE_MD" ]]; then
+    echo "FATAL: remote.md not found at $REMOTE_MD" >&2
+    exit 1
+fi
+
+SCRATCH="$(cd "$(mktemp -d)" && pwd -P)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+# ---------------------------------------------------------------------------
+# Assertion helpers (same shape as test-branches-loss-check.sh)
+# ---------------------------------------------------------------------------
+ok() { TOTAL=$((TOTAL + 1)); PASS=$((PASS + 1)); printf "  ${GREEN}PASS${NC}: %s\n" "$1"; }
+no() {
+    TOTAL=$((TOTAL + 1)); FAIL=$((FAIL + 1))
+    printf "  ${RED}FAIL${NC}: %s\n" "$1"
+    [[ -n "${2:-}" ]] && printf "        %s\n" "$2"
+    return 0
+}
+assert_eq()       { if [[ "$2" == "$3" ]]; then ok "$1"; else no "$1" "expected [$2], got [$3]"; fi; }
+assert_contains() { if [[ "$2" == *"$3"* ]]; then ok "$1"; else no "$1" "missing [$3] in [$2]"; fi; }
+assert_not_contains() { if [[ "$2" != *"$3"* ]]; then ok "$1"; else no "$1" "unexpected [$3] present"; fi; }
+
+# json_field <json> <key> -> value of a flat string/number/bool field
+json_field() {
+    printf '%s' "$1" | sed -n "s/.*\"$2\":\"\\([^\"]*\\)\".*/\\1/p; s/.*\"$2\":\\([0-9.a-z]*\\).*/\\1/p" | head -n1
+}
+
+# ---------------------------------------------------------------------------
+# A fixture repo + config layers. XDG_CONFIG_HOME points at a scratch dir so the
+# shared remote.env is a fixture; the repo `.env` lives at a scratch git root.
+# ---------------------------------------------------------------------------
+FIX="$SCRATCH/fixture"
+XDG="$FIX/xdg"
+REPO="$FIX/myrepo"
+SHARED="$XDG/repo/remote.env"
+mkdir -p "$XDG/repo" "$REPO"
+git -C "$REPO" init -q
+
+write_shared() { mkdir -p "$XDG/repo"; printf '%s\n' "$@" >"$SHARED"; }
+write_repo_env() { printf '%s\n' "$@" >"$REPO/.env"; }
+
+# run_rr <extra-env...> -- <args...>  -> runs the script in the fixture repo with
+# XDG_CONFIG_HOME set, SSH config redirected to scratch, and the mock aws on PATH.
+MOCK_BIN="$SCRATCH/bin"
+MOCK_LOG="$SCRATCH/aws.log"
+mkdir -p "$MOCK_BIN"
+RR_OUT=""; RR_ERR=""; RR_RC=0
+run_rr() {
+    local -a envs=()
+    while [[ "$1" != "--" ]]; do envs+=("$1"); shift; done
+    shift
+    : >"$MOCK_LOG"
+    local errf; errf="$(mktemp)"
+    RR_OUT="$(cd "$REPO" && env \
+        PATH="$MOCK_BIN:$PATH" \
+        XDG_CONFIG_HOME="$XDG" \
+        REPO_REMOTE_SSH_CONFIG="$SCRATCH/ssh_config" \
+        MOCK_AWS_LOG="$MOCK_LOG" \
+        "${envs[@]}" \
+        bash "$RR" "$@" 2>"$errf")"
+    RR_RC=$?
+    RR_ERR="$(cat "$errf")"; rm -f "$errf"
+}
+
+# ---------------------------------------------------------------------------
+# The mock `aws` CLI. Logs every invocation to $MOCK_AWS_LOG and returns canned
+# output for exactly the subcommands repo-remote.sh calls. Scenario is driven by
+# env vars so each test controls reuse/create/find behavior.
+# ---------------------------------------------------------------------------
+cat >"$MOCK_BIN/aws" <<'MOCK'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"${MOCK_AWS_LOG:-/dev/null}"
+case "$1 $2" in
+  "sts get-caller-identity")
+    [[ "${MOCK_AWS_AUTH_FAIL:-0}" == 1 ]] && exit 255
+    echo '{"Account":"123456789012","Arn":"arn:aws:iam::123456789012:user/test"}'; exit 0 ;;
+  "ec2 describe-images")
+    echo "${MOCK_AWS_AMI:-ami-0ubuntu2204}"; exit 0 ;;
+  "ec2 describe-instances")
+    # --instance-ids (pinned lookup) vs --filters (tag find)
+    if printf '%s' "$*" | grep -q -- '--instance-ids'; then
+      echo "${MOCK_AWS_STATE:-None}"
+    else
+      # tag find / status: emit configured rows (may be empty)
+      printf '%s' "${MOCK_AWS_FIND:-}"
+    fi
+    exit 0 ;;
+  "ec2 run-instances")
+    if [[ "${MOCK_AWS_QUOTA_FAIL:-0}" == 1 ]]; then
+      echo "An error occurred (VcpuLimitExceeded) when calling the RunInstances operation" >&2
+      exit 254
+    fi
+    echo "${MOCK_AWS_NEW_ID:-i-0newinstance}"; exit 0 ;;
+  "ec2 wait"|"ec2 start-instances"|"ec2 stop-instances"|"ec2 terminate-instances")
+    exit 0 ;;
+  *) exit 0 ;;
+esac
+MOCK
+chmod +x "$MOCK_BIN/aws"
+
+echo "repo-remote.sh test suite"
+echo "========================="
+echo ""
+
+# ---------------------------------------------------------------------------
+echo "-- the cost gate: missing required config fails LOUDLY, never defaults --"
+# ---------------------------------------------------------------------------
+write_shared "REPO_REMOTE_PROVIDER=aws" "AWS_ACCESS_KEY_ID=AKIA" "AWS_SECRET_ACCESS_KEY=sk" "AWS_REGION=us-west-2"
+rm -f "$REPO/.env"
+run_rr -- up --yes --json
+assert_eq   "missing instance type -> exit 2 (the cost gate)" "2" "$RR_RC"
+assert_contains "names the missing cost-relevant var" "$RR_ERR" "REPO_REMOTE_INSTANCE_TYPE"
+assert_not_contains "did NOT emit an up result (nothing provisioned)" "$RR_OUT" '"action":"up"'
+# The mock must not have been asked to launch anything.
+assert_eq "no cloud call made when the gate fails" "0" "$(grep -c 'run-instances' "$MOCK_LOG" 2>/dev/null)"
+
+# Missing credentials is the same loud failure, even with a type present.
+write_shared "REPO_REMOTE_PROVIDER=aws"
+write_repo_env "REPO_REMOTE_INSTANCE_TYPE=m5.2xlarge"
+run_rr -- up --yes --json
+assert_eq   "missing credentials -> exit 2" "2" "$RR_RC"
+assert_contains "names AWS_ACCESS_KEY_ID" "$RR_ERR" "AWS_ACCESS_KEY_ID"
+
+# Missing provider entirely.
+write_shared "AWS_ACCESS_KEY_ID=AKIA" "AWS_SECRET_ACCESS_KEY=sk" "AWS_REGION=us-west-2"
+write_repo_env "REPO_REMOTE_INSTANCE_TYPE=m5.2xlarge"
+run_rr -- up --yes --json
+assert_eq   "missing provider -> exit 2" "2" "$RR_RC"
+assert_contains "names REPO_REMOTE_PROVIDER" "$RR_ERR" "REPO_REMOTE_PROVIDER"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "-- --yes still requires a pre-supplied instance type (removes prompt, not consent) --"
+# ---------------------------------------------------------------------------
+write_shared "REPO_REMOTE_PROVIDER=aws" "AWS_ACCESS_KEY_ID=AKIA" "AWS_SECRET_ACCESS_KEY=sk" "AWS_REGION=us-west-2"
+rm -f "$REPO/.env"
+run_rr -- up --yes --json
+assert_eq "--yes without instance type STILL fails (exit 2)" "2" "$RR_RC"
+assert_not_contains "no instance was created" "$(cat "$MOCK_LOG")" "run-instances"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "-- config-layer precedence: repo .env overrides shared remote.env --"
+# ---------------------------------------------------------------------------
+write_shared "REPO_REMOTE_PROVIDER=aws" "AWS_ACCESS_KEY_ID=AKIA" "AWS_SECRET_ACCESS_KEY=sk" \
+             "AWS_REGION=us-west-2" "REPO_REMOTE_INSTANCE_TYPE=m5.large"
+write_repo_env "REPO_REMOTE_INSTANCE_TYPE=m5.2xlarge"
+run_rr -- up --json          # dry-run plan
+assert_eq "repo .env instance type wins over shared" "m5.2xlarge" "$(json_field "$RR_OUT" instance_type)"
+assert_eq "region resolved from shared layer" "us-west-2" "$(json_field "$RR_OUT" region)"
+# Shared provider stands when repo doesn't override it.
+assert_eq "provider resolved (shared)" "aws" "$(json_field "$RR_OUT" provider)"
+# Repo overrides provider too.
+write_repo_env "REPO_REMOTE_INSTANCE_TYPE=m5.2xlarge" "REPO_REMOTE_PROVIDER=gcp"
+run_rr -- up --json
+assert_eq "repo .env provider (gcp) overrides shared (aws) -> gcp gate" "2" "$RR_RC"
+assert_contains "gcp path now demands GCP creds" "$RR_ERR" "GCP_PROJECT"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "-- dry-run plan: cost shown, NOTHING provisioned (plan-before-spend) --"
+# ---------------------------------------------------------------------------
+write_shared "REPO_REMOTE_PROVIDER=aws" "AWS_ACCESS_KEY_ID=AKIA" "AWS_SECRET_ACCESS_KEY=sk" "AWS_REGION=us-west-2"
+write_repo_env "REPO_REMOTE_INSTANCE_TYPE=m5.2xlarge"
+run_rr -- up --json
+assert_eq   "plain up is a dry run -> exit 0" "0" "$RR_RC"
+assert_contains "output marked dry_run" "$RR_OUT" '"dry_run":true'
+assert_eq   "plan carries the estimated hourly cost" "0.384" "$(json_field "$RR_OUT" estimated_hourly_cost_usd)"
+assert_eq   "no cloud mutation in dry run" "0" "$(grep -c 'run-instances' "$MOCK_LOG" 2>/dev/null)"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "-- JSON output shape on a real (mocked) provision --"
+# ---------------------------------------------------------------------------
+run_rr MOCK_AWS_NEW_ID=i-0abc123 MOCK_AWS_STATE=None -- up --yes --json
+assert_eq   "up --yes provisions -> exit 0" "0" "$RR_RC"
+assert_contains "JSON has instance id"   "$RR_OUT" '"instance_id":"i-0abc123"'
+assert_contains "JSON has a public ip field" "$RR_OUT" '"public_ip"'
+assert_contains "JSON has the ssh alias"  "$RR_OUT" '"ssh_alias":"repo-remote-myrepo"'
+assert_contains "JSON has estimated hourly cost" "$RR_OUT" '"estimated_hourly_cost_usd":0.384'
+assert_contains "JSON reports it created (not reused)" "$RR_OUT" '"reused":false'
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "-- provisioning applies the required tag, disk, type and idle guard --"
+# ---------------------------------------------------------------------------
+LOGTXT="$(cat "$MOCK_LOG")"
+assert_contains "instance tagged repo-remote=<name>" "$LOGTXT" "repo-remote,Value=myrepo"
+assert_contains "requested instance type is passed"  "$LOGTXT" "m5.2xlarge"
+assert_contains "disk size from config is applied"   "$LOGTXT" "VolumeSize=50"
+assert_contains "user-data (idle guard) is passed"   "$LOGTXT" "user-data"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "-- idle-shutdown guard content --"
+# ---------------------------------------------------------------------------
+# The idle guard embeds IDLE_MIN, sourced from config; assert that value flows
+# through by setting a distinct idle window and confirming the plan echoes it.
+write_repo_env "REPO_REMOTE_INSTANCE_TYPE=m5.2xlarge" "REPO_REMOTE_IDLE_SHUTDOWN_MIN=45"
+run_rr -- up --json
+assert_eq "idle-shutdown window is read from config" "45" "$(json_field "$RR_OUT" idle_shutdown_min)"
+write_repo_env "REPO_REMOTE_INSTANCE_TYPE=m5.2xlarge"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "-- instance-id write-back to repo .env (never the shared file) --"
+# ---------------------------------------------------------------------------
+run_rr MOCK_AWS_NEW_ID=i-0written MOCK_AWS_STATE=None -- up --yes --json
+assert_contains "new id written back to repo .env" "$(cat "$REPO/.env")" "REPO_REMOTE_INSTANCE_ID=i-0written"
+assert_not_contains "shared remote.env is NOT touched with an instance id" "$(cat "$SHARED")" "REPO_REMOTE_INSTANCE_ID"
+# A second run updates in place rather than appending a duplicate line.
+run_rr MOCK_AWS_NEW_ID=i-0second MOCK_AWS_STATE=None -- up --yes --json
+assert_eq "write-back updates in place (one line only)" "1" "$(grep -c '^REPO_REMOTE_INSTANCE_ID=' "$REPO/.env")"
+assert_contains "write-back reflects the newest id" "$(cat "$REPO/.env")" "REPO_REMOTE_INSTANCE_ID=i-0second"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "-- reuse: a running pinned instance is reused, not recreated --"
+# ---------------------------------------------------------------------------
+write_repo_env "REPO_REMOTE_INSTANCE_TYPE=m5.2xlarge" "REPO_REMOTE_INSTANCE_ID=i-0pinned"
+run_rr MOCK_AWS_STATE=running -- up --yes --json
+assert_contains "reused the pinned running instance" "$RR_OUT" '"instance_id":"i-0pinned"'
+assert_contains "reported reused=true" "$RR_OUT" '"reused":true'
+assert_eq "no new instance launched on reuse" "0" "$(grep -c 'run-instances' "$MOCK_LOG" 2>/dev/null)"
+# A stopped pinned instance is started, still reused.
+run_rr MOCK_AWS_STATE=stopped -- up --yes --json
+assert_contains "stopped pinned instance is started" "$(cat "$MOCK_LOG")" "start-instances"
+assert_contains "still reported reused" "$RR_OUT" '"reused":true'
+write_repo_env "REPO_REMOTE_INSTANCE_TYPE=m5.2xlarge"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "-- GPU detection + cost --"
+# ---------------------------------------------------------------------------
+write_repo_env "REPO_REMOTE_INSTANCE_TYPE=g6e.xlarge"
+run_rr -- up --json
+assert_contains "GPU family flagged gpu=true" "$RR_OUT" '"gpu":true'
+assert_eq "GPU instance carries a GPU-tier cost" "1.861" "$(json_field "$RR_OUT" estimated_hourly_cost_usd)"
+# Unknown type -> approximate cost, still a number present.
+write_repo_env "REPO_REMOTE_INSTANCE_TYPE=zz.unknown"
+run_rr -- up --json
+assert_contains "unknown type flagged approximate" "$RR_OUT" '"estimated_cost_approximate":true'
+assert_contains "unknown type still carries a cost number" "$RR_OUT" '"estimated_hourly_cost_usd":0.20'
+write_repo_env "REPO_REMOTE_INSTANCE_TYPE=m5.2xlarge"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "-- GPU quota (VcpuLimitExceeded) surfaces the exact remediation --"
+# ---------------------------------------------------------------------------
+write_repo_env "REPO_REMOTE_INSTANCE_TYPE=g6e.xlarge"
+run_rr MOCK_AWS_QUOTA_FAIL=1 MOCK_AWS_STATE=None -- up --yes --json
+assert_eq   "quota failure -> non-zero exit" "4" "$RR_RC"
+assert_contains "names the Service Quotas code" "$RR_ERR" "L-DB2E81BA"
+write_repo_env "REPO_REMOTE_INSTANCE_TYPE=m5.2xlarge"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "-- status: lists tagged instances as JSON --"
+# ---------------------------------------------------------------------------
+run_rr MOCK_AWS_FIND="i-0abc running m5.2xlarge 1.2.3.4 2026-07-29T00:00:00Z" -- status --json
+assert_eq   "status -> exit 0" "0" "$RR_RC"
+assert_contains "status action" "$RR_OUT" '"action":"status"'
+assert_contains "status lists the instance" "$RR_OUT" '"instance_id":"i-0abc"'
+assert_contains "status carries state" "$RR_OUT" '"state":"running"'
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "-- down: dry-run vs --yes, and --delete terminates --"
+# ---------------------------------------------------------------------------
+run_rr MOCK_AWS_FIND="i-0abc" -- down --json      # no --yes -> dry-run
+assert_contains "down without --yes is a dry run" "$RR_OUT" '"disposition":"dry-run"'
+assert_eq "dry-run down does not stop anything" "0" "$(grep -c 'stop-instances' "$MOCK_LOG" 2>/dev/null)"
+run_rr MOCK_AWS_FIND="i-0abc" -- down --yes --json
+assert_contains "down --yes stops" "$RR_OUT" '"disposition":"stopped"'
+assert_contains "stop-instances actually called" "$(cat "$MOCK_LOG")" "stop-instances"
+run_rr MOCK_AWS_FIND="i-0abc" -- down --yes --delete --json
+assert_contains "down --yes --delete terminates" "$RR_OUT" '"disposition":"terminated"'
+assert_contains "terminate-instances actually called" "$(cat "$MOCK_LOG")" "terminate-instances"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "-- auth failure stops loudly, no fallback --"
+# ---------------------------------------------------------------------------
+run_rr MOCK_AWS_AUTH_FAIL=1 MOCK_AWS_STATE=None -- up --yes --json
+assert_eq "auth failure -> exit 3" "3" "$RR_RC"
+assert_eq "no instance launched after auth failure" "0" "$(grep -c 'run-instances' "$MOCK_LOG" 2>/dev/null)"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "-- usage errors --"
+# ---------------------------------------------------------------------------
+run_rr -- ; assert_eq "no action -> usage error (64)" "64" "$RR_RC"
+run_rr -- bogus ; assert_eq "unknown arg -> usage error (64)" "64" "$RR_RC"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "-- doc drift: remote.md documents what the script implements --"
+# ---------------------------------------------------------------------------
+MD="$(cat "$REMOTE_MD")"
+assert_contains "remote.md documents the headless entry point" "$MD" "repo-remote"
+assert_contains "remote.md documents 'up' provisioning verb" "$MD" "repo-remote up"
+assert_contains "remote.md documents --yes for the non-interactive path" "$MD" "--yes"
+assert_contains "remote.md documents --json machine-readable output" "$MD" "--json"
+assert_contains "remote.md still documents --status" "$MD" "--status"
+assert_contains "remote.md still documents --down" "$MD" "--down"
+assert_contains "remote.md documents the repo-remote=<name> tag" "$MD" "repo-remote=<name>"
+assert_contains "remote.md documents the cost-gate contract" "$MD" "REPO_REMOTE_INSTANCE_TYPE"
+assert_contains "remote.md states --yes preserves consent" "$MD" "removes the prompt, not the consent"
+
+# The interactive steps must DELEGATE to the shared script, not re-issue cloud
+# CLI calls from prose (the "no behavior drift" acceptance criterion).
+assert_contains "remote.md delegates provisioning to the shared script" "$MD" "scripts/repo/repo-remote.sh"
+
+# install.sh must ship the script to consumer repos (packaging path).
+INSTALL_SH="$REPO_ROOT/install.sh"
+if [[ -f "$INSTALL_SH" ]]; then
+    IN="$(cat "$INSTALL_SH")"
+    assert_contains "install.sh copies repo-remote.sh into the skill scripts dir" \
+        "$IN" "scripts/repo-remote.sh"
+    assert_contains "install.sh chmod +x the installed script" \
+        "$IN" "chmod +x"
+fi
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "========================================="
+echo "  Total:  $TOTAL"
+printf "  ${GREEN}Passed${NC}: %s\n" "$PASS"
+printf "  ${RED}Failed${NC}: %s\n" "$FAIL"
+echo "========================================="
+
+if [[ $FAIL -gt 0 ]]; then
+    printf "\n${RED}TESTS FAILED${NC}\n"
+    exit 1
+fi
+printf "\n${GREEN}ALL TESTS PASSED${NC}\n"
+exit 0

--- a/hooks/repo/tests/run.sh
+++ b/hooks/repo/tests/run.sh
@@ -15,8 +15,9 @@
 # to the headline aggregate, so a miswired block can never make the headline
 # diverge from the breakdown (repo#44). Currently delegated:
 # test-guard-destructive.sh (the full guard regression suite),
-# test-session-start-handoff.sh, test-install-claude-md-markers.sh, and
-# commands/repo/tests/test-branches-loss-check.sh.
+# test-session-start-handoff.sh, test-install-claude-md-markers.sh,
+# commands/repo/tests/test-branches-loss-check.sh, and
+# commands/repo/tests/test-repo-remote.sh.
 #
 # `pnpm test` is this repo's only automated gate — there is no CI — so it must
 # run every case, not a smoke subset (repo#36).
@@ -363,6 +364,41 @@ else
     PASS=$((PASS + BL_PASS))
     FAIL=$((FAIL + BL_FAIL))
     record_suite "test-branches-loss-check.sh" "$BL_PASS" "$BL_FAIL" "branches.md loss check"
+fi
+
+# remote.md's provisioning contract is extracted into scripts/repo/repo-remote.sh
+# (the headless entry point for /repo:remote, repo#52). Like the loss-check suite
+# above, its tests live outside hooks/repo/tests/ but `pnpm test` stays the one
+# entry point, so delegate here and fold the real PASS/FAIL counts into the totals.
+echo
+echo "-- repo-remote.sh headless provisioning (delegated suite) --"
+RR_TEST="$TESTS_DIR/../../../commands/repo/tests/test-repo-remote.sh"
+if [[ ! -f "$RR_TEST" ]]; then
+    FAIL=$((FAIL + 1))
+    record_suite "test-repo-remote.sh" 0 1 "not found"
+    printf '  FAIL %-52s -> not found at %s\n' "test-repo-remote.sh" "$RR_TEST"
+else
+    RR_OUT="$(bash "$RR_TEST" 2>&1)"
+    RR_STATUS=$?
+    RR_PASS="$(suite_count Passed "$RR_OUT")"
+    RR_FAIL="$(suite_count Failed "$RR_OUT")"
+    if ! [[ "$RR_PASS" =~ ^[0-9]+$ && "$RR_FAIL" =~ ^[0-9]+$ ]]; then
+        RR_PASS=0
+        RR_FAIL=1
+        printf '  FAIL %-52s -> no parseable summary (exit %s); output tail follows\n' \
+            "test-repo-remote.sh" "$RR_STATUS"
+        strip_ansi "$RR_OUT" | tail -30 | sed 's/^/    /'
+    elif [[ "$RR_STATUS" -ne 0 || "$RR_FAIL" -ne 0 ]]; then
+        [[ "$RR_FAIL" -eq 0 ]] && RR_FAIL=1
+        printf '  FAIL %-52s -> %s pass, %s fail (exit %s); failures follow\n' \
+            "test-repo-remote.sh" "$RR_PASS" "$RR_FAIL" "$RR_STATUS"
+        strip_ansi "$RR_OUT" | grep -E '^ *FAIL' | sed 's/^/  /'
+    else
+        printf '  ok   %-52s -> %s cases pass\n' "test-repo-remote.sh" "$RR_PASS"
+    fi
+    PASS=$((PASS + RR_PASS))
+    FAIL=$((FAIL + RR_FAIL))
+    record_suite "test-repo-remote.sh" "$RR_PASS" "$RR_FAIL" "remote.md provisioning contract"
 fi
 
 echo

--- a/install.sh
+++ b/install.sh
@@ -222,6 +222,7 @@ if [[ "$DRY_RUN" == true ]]; then
   echo "  $TARGET/.claude/skills/repo/.install-local.json (machine-local, gitignored)"
   echo "  $TARGET/.claude/skills/repo/hooks/guard-destructive.sh"
   echo "  $TARGET/.claude/skills/repo/hooks/session-start-handoff.sh"
+  echo "  $TARGET/.claude/skills/repo/scripts/repo-remote.sh"
   echo "  $TARGET/.claude/settings.json (merge PreToolUse→Bash guard hook; idempotent, coexistence-aware)"
   echo "  $TARGET/.claude/settings.json (merge SessionStart→${SESSIONSTART_SOURCES[*]} handoff-note hook; idempotent, coexistence-aware)"
   while IFS= read -r cmd; do
@@ -457,6 +458,19 @@ install_file "$SOURCE_ROOT/hooks/repo/session-start-handoff.sh" \
 chmod +x "$TARGET/.claude/skills/repo/hooks/session-start-handoff.sh" 2>/dev/null || true
 success "Installed .claude/skills/repo/hooks/session-start-handoff.sh"
 merge_settings_sessionstart_hook
+
+# 3d. Headless provisioning script for /repo:remote. Same colocation + chmod
+# rationale as the hooks above: it lives inside .claude/skills/repo/ so
+# uninstall's `rm -rf` removes it for free, and render+copy drops the exec bit
+# so we re-set it. This is the non-interactive entry point the interactive
+# skill delegates to and that a caller (e.g. loom's `fleet add-worker`) invokes
+# directly — without this copy step the script would ship in the source repo
+# but never reach a consumer repo (repo#52).
+mkdir -p "$TARGET/.claude/skills/repo/scripts"
+install_file "$SOURCE_ROOT/scripts/repo/repo-remote.sh" \
+  "$TARGET/.claude/skills/repo/scripts/repo-remote.sh" "scripts/repo/repo-remote.sh"
+chmod +x "$TARGET/.claude/skills/repo/scripts/repo-remote.sh" 2>/dev/null || true
+success "Installed .claude/skills/repo/scripts/repo-remote.sh"
 
 # 4. CLAUDE.md block (replace existing block in place, else append).
 # Skipped in dev mode: the symlinked install is machine-local (absolute symlinks

--- a/scripts/repo/repo-remote.sh
+++ b/scripts/repo/repo-remote.sh
@@ -1,0 +1,747 @@
+#!/usr/bin/env bash
+# repo-remote.sh — headless, scriptable entry point for /repo:remote provisioning.
+#
+# This is the non-interactive implementation of the provisioning contract
+# documented (as prose) in commands/repo/remote.md. The interactive skill wraps
+# this script with its wizard / cost-confirmation UX and, once the human has
+# confirmed, calls `repo-remote up --yes`; a caller such as loom's
+# `fleet add-worker` invokes the same `up --yes --json` path directly. There is
+# ONE implementation of the contract so the two paths cannot drift (repo#52).
+#
+# The seam this produces, consumed by loom fleet orchestration: "a reachable
+# Ubuntu box, this repo's SSH alias written, instance id recorded" — emitted as
+# machine-readable JSON (instance id, public IP, SSH alias, estimated hourly
+# cost) so a caller can implement loom's "plan shown before money is spent" rule.
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# STABLE INTERFACE (downstream tooling gates on this via the package version)
+# ─────────────────────────────────────────────────────────────────────────────
+#
+# Subcommands (both the `up`/`down`/`status` verbs and the remote.md-style
+# `--status`/`--down` flags are accepted, for parity with the prose command):
+#
+#   repo-remote up [--yes] [--json] [aws|gcp]     Provision (or reuse) an instance.
+#       Without --yes: a DRY-RUN plan (resolved spec + estimated cost) is emitted
+#       and NOTHING is created — this is the "plan shown before money spent" path.
+#       With --yes: the plan is executed. --yes removes the *prompt*, never the
+#       *consent requirement*: a cost-relevant field missing from config is a
+#       loud, non-zero-exit failure, never a silent default (repo#52 cost gate).
+#
+#   repo-remote status|--status [--json] [aws|gcp]   List instances this command
+#       created (tagged repo-remote=<name>) with state; no mutation.
+#
+#   repo-remote down|--down [--yes] [--delete] [--json] [aws|gcp]   Teardown.
+#       Without --yes: a DRY-RUN listing of exactly what would stop/terminate.
+#       With --yes: stop them; add --delete to terminate (disk goes with it).
+#
+# Config: two layers, shared first then repo (repo overrides), matching the
+# skill exactly:
+#   1. ${XDG_CONFIG_HOME:-$HOME/.config}/repo/remote.env   (shared cloud creds)
+#   2. <git-root>/.env                                     (per-repo machine)
+#
+# Cost gate (repo#52 — the highest-cost-of-being-wrong element): `up` (with or
+# without --yes) REQUIRES the provider, that provider's credentials, and
+# REPO_REMOTE_INSTANCE_TYPE to be present in config. Instance type is the
+# cost-relevant field and is NEVER defaulted here — that removes interactivity,
+# not consent. Non-cost-relevant fields (disk, idle window, image) do fall back
+# to built-in defaults, matching the prose command.
+#
+# Exit codes:
+#   0  success (including a dry-run plan)
+#   2  missing / invalid required config (the cost gate; loud failure)
+#   3  provider authentication failed
+#   4  cloud operation failed
+#   64 usage error
+#
+# Testability hooks (honored so the suite can exercise the full contract against
+# mocked cloud CLIs without touching real infrastructure or a real ~/.ssh):
+#   XDG_CONFIG_HOME            locates the shared remote.env (already standard)
+#   REPO_REMOTE_SSH_CONFIG     SSH config file to write the alias into
+#                              (default: ~/.ssh/config)
+#   PATH                       mock `aws`/`gcloud` are picked up from PATH
+#
+set -uo pipefail
+
+# ── output helpers ──────────────────────────────────────────────────────────
+_is_tty() { [[ -t 2 ]]; }
+log()  { printf '%s\n' "repo-remote: $*" >&2; }
+die()  { local code="$1"; shift; printf '%s\n' "repo-remote: ERROR: $*" >&2; exit "$code"; }
+
+JSON_OUT=false   # --json
+YES=false        # --yes
+DELETE=false     # --down --delete
+ACTION=""        # up | down | status
+PROVIDER_ARG=""  # aws | gcp (positional override)
+
+# ── JSON emission (no jq dependency for output; values are controlled) ──────
+# json_escape <string> -> a JSON string body (without surrounding quotes)
+json_escape() {
+  local s="$1"
+  s="${s//\\/\\\\}"
+  s="${s//\"/\\\"}"
+  s="${s//$'\n'/\\n}"
+  s="${s//$'\t'/\\t}"
+  s="${s//$'\r'/}"
+  printf '%s' "$s"
+}
+
+# ── config loading ──────────────────────────────────────────────────────────
+# Load the two env layers into the environment, shared first then repo (repo
+# wins because it is sourced last). Mirrors commands/repo/remote.md step 2.
+SHARED_ENV=""
+REPO_ENV=""
+GIT_ROOT=""
+
+resolve_paths() {
+  SHARED_ENV="${XDG_CONFIG_HOME:-$HOME/.config}/repo/remote.env"
+  GIT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+  [[ -n "$GIT_ROOT" ]] && REPO_ENV="$GIT_ROOT/.env"
+}
+
+load_config() {
+  set -a
+  # shellcheck disable=SC1090
+  [[ -f "$SHARED_ENV" ]] && . "$SHARED_ENV"
+  # shellcheck disable=SC1090
+  [[ -n "$REPO_ENV" && -f "$REPO_ENV" ]] && . "$REPO_ENV"
+  set +a
+}
+
+# ── effective settings ──────────────────────────────────────────────────────
+PROVIDER=""
+NAME=""
+INSTANCE_TYPE=""
+INSTANCE_ID=""
+DISK_GB=""
+IMAGE=""
+GPU_ACCEL=""       # GCP accelerator string, e.g. nvidia-l4:1
+IDLE_MIN=""
+IS_GPU=false
+REGION=""
+COST_HOURLY=""
+COST_APPROX=false
+
+# GPU-family detection: infer a GPU host from the instance family so the caller
+# needn't set a separate flag (remote.md "GPU hosts").
+is_gpu_family() {  # <provider> <instance-type>
+  local p="$1" t="$2"
+  [[ -n "${GPU_ACCEL:-}" ]] && return 0
+  case "$p" in
+    aws) [[ "$t" =~ ^(g3|g4|g4dn|g5|g5g|g6|g6e|p2|p3|p4|p4d|p5)\. ]] && return 0 ;;
+    gcp) [[ "$t" =~ ^(g2|a2|a3)- ]] && return 0 ;;
+  esac
+  return 1
+}
+
+# Approximate on-demand USD/hour by instance type. Unknown types fall back to a
+# GPU/non-GPU heuristic flagged approximate — the JSON always carries a number
+# so a caller can implement a budget check, and never silently claims precision.
+estimate_cost() {  # sets COST_HOURLY, COST_APPROX
+  local t="$1"
+  COST_APPROX=false
+  case "$t" in
+    # AWS general purpose / compute
+    t3.medium)   COST_HOURLY=0.0416 ;;
+    t3.large)    COST_HOURLY=0.0832 ;;
+    t3.xlarge)   COST_HOURLY=0.1664 ;;
+    t3.2xlarge)  COST_HOURLY=0.3328 ;;
+    m5.large)    COST_HOURLY=0.096  ;;
+    m5.xlarge)   COST_HOURLY=0.192  ;;
+    m5.2xlarge)  COST_HOURLY=0.384  ;;
+    m5.4xlarge)  COST_HOURLY=0.768  ;;
+    m6i.xlarge)  COST_HOURLY=0.192  ;;
+    m6i.2xlarge) COST_HOURLY=0.384  ;;
+    c5.xlarge)   COST_HOURLY=0.17   ;;
+    c5.2xlarge)  COST_HOURLY=0.34   ;;
+    c5.4xlarge)  COST_HOURLY=0.68   ;;
+    # AWS GPU
+    g4dn.xlarge) COST_HOURLY=0.526  ;;
+    g5.xlarge)   COST_HOURLY=1.006  ;;
+    g5.2xlarge)  COST_HOURLY=1.212  ;;
+    g6.xlarge)   COST_HOURLY=0.8048 ;;
+    g6e.xlarge)  COST_HOURLY=1.861  ;;
+    g6e.2xlarge) COST_HOURLY=2.242  ;;
+    p4d.24xlarge) COST_HOURLY=32.77 ;;
+    # GCP predefined
+    e2-standard-2)  COST_HOURLY=0.067 ;;
+    e2-standard-4)  COST_HOURLY=0.134 ;;
+    e2-standard-8)  COST_HOURLY=0.268 ;;
+    n1-standard-4)  COST_HOURLY=0.19  ;;
+    n1-standard-8)  COST_HOURLY=0.38  ;;
+    g2-standard-4)  COST_HOURLY=0.71  ;;
+    g2-standard-8)  COST_HOURLY=0.85  ;;
+    a2-highgpu-1g)  COST_HOURLY=3.67  ;;
+    *)
+      COST_APPROX=true
+      if [[ "$IS_GPU" == true ]]; then COST_HOURLY=1.50; else COST_HOURLY=0.20; fi
+      ;;
+  esac
+  # A GCP accelerator adds to the machine price; fold in a rough per-card cost so
+  # the estimate for GPU-on-GCP is not silently the bare-machine price.
+  if [[ -n "${GPU_ACCEL:-}" && "$PROVIDER" == gcp ]]; then
+    COST_APPROX=true
+    COST_HOURLY="$(awk -v c="$COST_HOURLY" 'BEGIN{printf "%.4f", c + 0.70}')"
+  fi
+}
+
+resolve_settings() {
+  PROVIDER="${PROVIDER_ARG:-${REPO_REMOTE_PROVIDER:-}}"
+  # lower-case the provider
+  PROVIDER="$(printf '%s' "$PROVIDER" | tr '[:upper:]' '[:lower:]')"
+
+  NAME="$(basename "${GIT_ROOT:-$PWD}")"
+
+  INSTANCE_TYPE="${REPO_REMOTE_INSTANCE_TYPE:-}"
+  INSTANCE_ID="${REPO_REMOTE_INSTANCE_ID:-}"
+  GPU_ACCEL="${REPO_REMOTE_GPU:-}"
+  IMAGE="${REPO_REMOTE_IMAGE:-}"
+
+  # Non-cost-relevant fields DO fall back to defaults (matches the prose command).
+  DISK_GB="${REPO_REMOTE_DISK_GB:-50}"
+  IDLE_MIN="${REPO_REMOTE_IDLE_SHUTDOWN_MIN:-120}"
+
+  case "$PROVIDER" in
+    aws) REGION="${AWS_REGION:-${AWS_DEFAULT_REGION:-}}" ;;
+    gcp) REGION="${GCP_ZONE:-}" ;;
+  esac
+
+  if [[ -n "$INSTANCE_TYPE" ]] && is_gpu_family "$PROVIDER" "$INSTANCE_TYPE"; then
+    IS_GPU=true
+  fi
+  [[ -n "$INSTANCE_TYPE" ]] && estimate_cost "$INSTANCE_TYPE"
+}
+
+# ── the cost gate ───────────────────────────────────────────────────────────
+# Enforce that every field whose absence could cause an *unexpected* bill is
+# present in config. This is what makes `--yes` safe: it removes the interactive
+# prompt but not the requirement that the human pre-supplied the budget-relevant
+# choices. Missing config fails loudly (exit 2), never a silent default.
+require_cost_config() {
+  local missing=()
+
+  [[ -n "$PROVIDER" ]] || missing+=("REPO_REMOTE_PROVIDER (or an aws|gcp argument)")
+  case "$PROVIDER" in
+    aws)
+      [[ -n "${AWS_ACCESS_KEY_ID:-}" ]]     || missing+=("AWS_ACCESS_KEY_ID")
+      [[ -n "${AWS_SECRET_ACCESS_KEY:-}" ]] || missing+=("AWS_SECRET_ACCESS_KEY")
+      [[ -n "$REGION" ]]                    || missing+=("AWS_REGION")
+      ;;
+    gcp)
+      [[ -n "${GCP_PROJECT:-}" ]]                     || missing+=("GCP_PROJECT")
+      [[ -n "$REGION" ]]                              || missing+=("GCP_ZONE")
+      [[ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]]  || missing+=("GOOGLE_APPLICATION_CREDENTIALS")
+      ;;
+    "") : ;;  # provider itself already reported above
+    *)  die 2 "unknown provider '$PROVIDER' (expected aws or gcp)" ;;
+  esac
+
+  # THE cost-relevant field. Never defaulted — an unpinned instance type is
+  # exactly how an unexpected bill happens.
+  [[ -n "$INSTANCE_TYPE" ]] || missing+=("REPO_REMOTE_INSTANCE_TYPE (required — no default, so a run never silently picks a billable size)")
+
+  if [[ ${#missing[@]} -gt 0 ]]; then
+    local m
+    log "cannot proceed — required config is missing (no silent defaults for cost-relevant fields):"
+    for m in "${missing[@]}"; do log "  - $m"; done
+    log "set them in ${SHARED_ENV} (shared) or ${REPO_ENV:-<git-root>/.env} (per-repo), or run /repo:remote --configure."
+    exit 2
+  fi
+}
+
+# ── the idle-shutdown guard (cloud-init user-data) ──────────────────────────
+# A forgotten VM — GPU ones especially — must turn itself off. Emitted as a
+# cloud-init script that installs a cron watchdog running `shutdown -h` after
+# IDLE_MIN minutes with no active SSH session and low CPU.
+idle_guard_userdata() {
+  cat <<EOF
+#!/bin/bash
+# repo-remote idle-shutdown guard (idle window: ${IDLE_MIN} min)
+cat >/usr/local/bin/repo-remote-idle-check <<'GUARD'
+#!/bin/bash
+IDLE_MIN=${IDLE_MIN}
+STAMP=/var/run/repo-remote-idle.stamp
+if who | grep -q . || [ "\$(awk '{print (\$1 > 0.2)}' /proc/loadavg)" = "1" ]; then
+  date +%s > "\$STAMP"; exit 0
+fi
+[ -f "\$STAMP" ] || { date +%s > "\$STAMP"; exit 0; }
+NOW=\$(date +%s); LAST=\$(cat "\$STAMP")
+if [ \$(( (NOW - LAST) / 60 )) -ge "\$IDLE_MIN" ]; then
+  /sbin/shutdown -h now "repo-remote: idle for \${IDLE_MIN}m"
+fi
+GUARD
+chmod +x /usr/local/bin/repo-remote-idle-check
+echo "* * * * * root /usr/local/bin/repo-remote-idle-check" >/etc/cron.d/repo-remote-idle
+EOF
+}
+
+# ── AWS provider ────────────────────────────────────────────────────────────
+aws_authenticate() {
+  aws sts get-caller-identity >/dev/null 2>&1 \
+    || die 3 "AWS authentication failed with the resolved credentials (aws sts get-caller-identity). Not falling back to ambient/other credentials."
+}
+
+# Resolve the AMI into RESOLVED_AMI: an explicit override wins; a GPU host
+# defaults to the AWS Deep Learning Base OSS Nvidia Driver GPU AMI (Ubuntu
+# 22.04); otherwise the latest Ubuntu 22.04 LTS. (remote.md "GPU hosts".)
+# Sets a global (rather than echoing) so a `die` here propagates to the whole
+# process instead of being swallowed by a `$(...)` subshell.
+RESOLVED_AMI=""
+aws_resolve_image() {
+  if [[ -n "$IMAGE" ]]; then RESOLVED_AMI="$IMAGE"; return 0; fi
+  local q name
+  if [[ "$IS_GPU" == true ]]; then
+    name='Deep Learning Base OSS Nvidia Driver GPU AMI (Ubuntu 22.04)*'
+    q="$(aws ec2 describe-images --owners amazon \
+      --filters "Name=name,Values=$name" \
+      --query 'sort_by(Images,&CreationDate)[-1].ImageId' --output text 2>/dev/null)"
+  else
+    name='ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*'
+    q="$(aws ec2 describe-images --owners 099720109477 \
+      --filters "Name=name,Values=$name" \
+      --query 'sort_by(Images,&CreationDate)[-1].ImageId' --output text 2>/dev/null)"
+  fi
+  [[ -n "$q" && "$q" != "None" ]] || die 4 "could not resolve an AMI for ${INSTANCE_TYPE} (GPU=${IS_GPU}). Set REPO_REMOTE_IMAGE to override."
+  RESOLVED_AMI="$q"
+}
+
+# Describe a single instance's state; echoes state name or "missing".
+aws_instance_state() {  # <instance-id>
+  local out
+  out="$(aws ec2 describe-instances --instance-ids "$1" \
+        --query 'Reservations[0].Instances[0].State.Name' --output text 2>/dev/null)" || { echo missing; return; }
+  [[ -n "$out" && "$out" != "None" ]] && echo "$out" || echo missing
+}
+
+# Find a running|stopped instance previously created for this repo (by tag).
+aws_find_tagged() {  # echoes "<id> <state>" or empty
+  aws ec2 describe-instances \
+    --filters "Name=tag:repo-remote,Values=${NAME}" \
+              "Name=instance-state-name,Values=running,stopped,stopping,pending" \
+    --query 'Reservations[].Instances[].[InstanceId,State.Name]' --output text 2>/dev/null \
+    | grep -v '^None' | head -n1
+}
+
+aws_public_ip() {  # <instance-id>
+  aws ec2 describe-instances --instance-ids "$1" \
+    --query 'Reservations[0].Instances[0].PublicIpAddress' --output text 2>/dev/null
+}
+
+# Create a fresh instance into CREATED_ID (global, so a `die` propagates rather
+# than being swallowed by a command-substitution subshell). run-instances is
+# invoked EXACTLY ONCE — capturing stdout and stderr in one call — because a
+# retry-to-read-the-error would risk launching a second billable instance.
+CREATED_ID=""
+aws_create() {
+  local ami sg key udfile errfile iid rc err
+  aws_resolve_image; ami="$RESOLVED_AMI"
+  key="${REPO_REMOTE_SSH_KEY_NAME:-}"
+  sg="${REPO_REMOTE_SECURITY_GROUP:-}"
+
+  udfile="$(mktemp)"; idle_guard_userdata >"$udfile"
+  errfile="$(mktemp)"
+
+  local -a args=(ec2 run-instances
+    --image-id "$ami"
+    --instance-type "$INSTANCE_TYPE"
+    --block-device-mappings "DeviceName=/dev/sda1,Ebs={VolumeSize=${DISK_GB}}"
+    --tag-specifications "ResourceType=instance,Tags=[{Key=repo-remote,Value=${NAME}}]"
+    --user-data "file://${udfile}"
+    --query 'Instances[0].InstanceId' --output text)
+  [[ -n "$key" ]] && args+=(--key-name "$key")
+  [[ -n "$sg" ]]  && args+=(--security-group-ids "$sg")
+
+  iid="$(aws "${args[@]}" 2>"$errfile")"; rc=$?
+  err="$(cat "$errfile" 2>/dev/null)"
+  rm -f "$udfile" "$errfile"
+
+  if [[ $rc -ne 0 || -z "$iid" || "$iid" == "None" ]]; then
+    # Surface the quota-exceeded case with the exact remediation (remote.md).
+    if printf '%s' "$err" | grep -q 'VcpuLimitExceeded'; then
+      die 4 "AWS GPU vCPU quota is 0 by default (VcpuLimitExceeded). Request a limit >= this type's vCPUs at Service Quotas -> EC2 -> quota code L-DB2E81BA, then retry."
+    fi
+    die 4 "aws ec2 run-instances failed: ${err:-unknown error}"
+  fi
+  CREATED_ID="$iid"
+}
+
+aws_up() {
+  aws_authenticate
+  local iid="" state="" reused=false
+
+  if [[ -n "$INSTANCE_ID" ]]; then
+    state="$(aws_instance_state "$INSTANCE_ID")"
+    case "$state" in
+      running)          iid="$INSTANCE_ID"; reused=true ;;
+      stopped|stopping) aws ec2 start-instances --instance-ids "$INSTANCE_ID" >/dev/null 2>&1 \
+                          || die 4 "failed to start stopped instance $INSTANCE_ID"
+                        iid="$INSTANCE_ID"; reused=true ;;
+      missing)          log "pinned REPO_REMOTE_INSTANCE_ID=$INSTANCE_ID no longer exists; creating a fresh instance."
+                        INSTANCE_ID="" ;;
+      *)                iid="$INSTANCE_ID"; reused=true ;;
+    esac
+  fi
+
+  if [[ -z "$iid" ]]; then
+    local found; found="$(aws_find_tagged)"
+    if [[ -n "$found" ]]; then
+      iid="$(printf '%s' "$found" | awk '{print $1}')"
+      state="$(printf '%s' "$found" | awk '{print $2}')"
+      reused=true
+      if [[ "$state" == stopped || "$state" == stopping ]]; then
+        aws ec2 start-instances --instance-ids "$iid" >/dev/null 2>&1 \
+          || die 4 "failed to start reused instance $iid"
+      fi
+    fi
+  fi
+
+  if [[ -z "$iid" ]]; then
+    aws_create           # sets CREATED_ID or dies (main-shell context)
+    iid="$CREATED_ID"
+    reused=false
+  fi
+
+  aws ec2 wait instance-running --instance-ids "$iid" >/dev/null 2>&1 || true
+  local ip; ip="$(aws_public_ip "$iid")"
+  [[ "$ip" == "None" ]] && ip=""
+
+  writeback_instance_id "$iid"
+  local alias; alias="$(write_ssh_alias "$ip")"
+
+  emit_up_result "$iid" "$ip" "$alias" "$reused"
+}
+
+aws_status() {
+  aws_authenticate
+  local rows
+  rows="$(aws ec2 describe-instances \
+    --filters "Name=tag:repo-remote,Values=${NAME}" \
+    --query 'Reservations[].Instances[].[InstanceId,State.Name,InstanceType,PublicIpAddress,LaunchTime]' \
+    --output text 2>/dev/null | grep -v '^None' || true)"
+  emit_status_result "$rows"
+}
+
+aws_down() {
+  aws_authenticate
+  local ids
+  if [[ -n "$INSTANCE_ID" ]]; then
+    ids="$INSTANCE_ID"
+  else
+    ids="$(aws ec2 describe-instances \
+      --filters "Name=tag:repo-remote,Values=${NAME}" \
+                "Name=instance-state-name,Values=running,stopped,stopping,pending" \
+      --query 'Reservations[].Instances[].InstanceId' --output text 2>/dev/null | grep -v '^None' || true)"
+  fi
+  ids="$(printf '%s' "$ids" | tr '\t' ' ' | xargs 2>/dev/null || true)"
+
+  if [[ -z "$ids" ]]; then
+    emit_down_result "" "noop"
+    return 0
+  fi
+
+  if [[ "$YES" != true ]]; then
+    emit_down_result "$ids" "dry-run"
+    return 0
+  fi
+
+  if [[ "$DELETE" == true ]]; then
+    # shellcheck disable=SC2086
+    aws ec2 terminate-instances --instance-ids $ids >/dev/null 2>&1 \
+      || die 4 "aws ec2 terminate-instances failed for: $ids"
+    emit_down_result "$ids" "terminated"
+  else
+    # shellcheck disable=SC2086
+    aws ec2 stop-instances --instance-ids $ids >/dev/null 2>&1 \
+      || die 4 "aws ec2 stop-instances failed for: $ids"
+    emit_down_result "$ids" "stopped"
+  fi
+}
+
+# ── GCP provider ────────────────────────────────────────────────────────────
+gcp_authenticate() {
+  gcloud auth activate-service-account --key-file="${GOOGLE_APPLICATION_CREDENTIALS}" >/dev/null 2>&1 \
+    || die 3 "GCP authentication failed (gcloud auth activate-service-account)."
+  gcloud config set project "${GCP_PROJECT}" >/dev/null 2>&1 || true
+}
+
+gcp_up() {
+  gcp_authenticate
+  local vm="repo-remote-${NAME}" ip="" reused=false state
+  state="$(gcloud compute instances describe "$vm" --zone "$REGION" \
+    --format='value(status)' 2>/dev/null || true)"
+  if [[ -n "$state" ]]; then
+    reused=true
+    if [[ "$state" != "RUNNING" ]]; then
+      gcloud compute instances start "$vm" --zone "$REGION" >/dev/null 2>&1 \
+        || die 4 "failed to start existing instance $vm"
+    fi
+  else
+    local -a args=(compute instances create "$vm"
+      --zone "$REGION"
+      --machine-type "$INSTANCE_TYPE"
+      --boot-disk-size "${DISK_GB}GB"
+      --labels "repo-remote=${NAME}"
+      --image-family "${IMAGE:-ubuntu-2204-lts}" --image-project "${REPO_REMOTE_IMAGE_PROJECT:-ubuntu-os-cloud}")
+    [[ -n "$GPU_ACCEL" ]] && args+=(--accelerator "type=${GPU_ACCEL%%:*},count=${GPU_ACCEL##*:}" --maintenance-policy TERMINATE)
+    local ud; ud="$(mktemp)"; idle_guard_userdata >"$ud"
+    args+=(--metadata-from-file "startup-script=${ud}")
+    gcloud "${args[@]}" >/dev/null 2>&1 || { rm -f "$ud"; die 4 "gcloud compute instances create failed for $vm"; }
+    rm -f "$ud"
+  fi
+  ip="$(gcloud compute instances describe "$vm" --zone "$REGION" \
+    --format='value(networkInterfaces[0].accessConfigs[0].natIP)' 2>/dev/null || true)"
+
+  writeback_instance_id "$vm"
+  local alias; alias="$(write_ssh_alias "$ip")"
+  emit_up_result "$vm" "$ip" "$alias" "$reused"
+}
+
+gcp_status() {
+  gcp_authenticate
+  local rows
+  rows="$(gcloud compute instances list \
+    --filter="labels.repo-remote=${NAME}" \
+    --format='value(name,status,machineType.basename(),networkInterfaces[0].accessConfigs[0].natIP,creationTimestamp)' 2>/dev/null || true)"
+  emit_status_result "$rows"
+}
+
+gcp_down() {
+  gcp_authenticate
+  local vm="repo-remote-${NAME}"
+  [[ -n "$INSTANCE_ID" ]] && vm="$INSTANCE_ID"
+  local exists
+  exists="$(gcloud compute instances describe "$vm" --zone "$REGION" --format='value(name)' 2>/dev/null || true)"
+  if [[ -z "$exists" ]]; then emit_down_result "" "noop"; return 0; fi
+  if [[ "$YES" != true ]]; then emit_down_result "$vm" "dry-run"; return 0; fi
+  if [[ "$DELETE" == true ]]; then
+    gcloud compute instances delete "$vm" --zone "$REGION" --quiet >/dev/null 2>&1 \
+      || die 4 "gcloud compute instances delete failed for $vm"
+    emit_down_result "$vm" "terminated"
+  else
+    gcloud compute instances stop "$vm" --zone "$REGION" --quiet >/dev/null 2>&1 \
+      || die 4 "gcloud compute instances stop failed for $vm"
+    emit_down_result "$vm" "stopped"
+  fi
+}
+
+# ── write-back + SSH alias ──────────────────────────────────────────────────
+# Write the new instance id back to the repo's .env (git root, never the shared
+# file — the handle is per-repo), updating in place or appending. remote.md §4.
+writeback_instance_id() {  # <instance-id>
+  local id="$1"
+  [[ -n "$REPO_ENV" ]] || return 0
+  if [[ -f "$REPO_ENV" ]] && grep -q '^REPO_REMOTE_INSTANCE_ID=' "$REPO_ENV"; then
+    local tmp; tmp="$(mktemp)"
+    while IFS= read -r line || [[ -n "$line" ]]; do
+      if [[ "$line" == REPO_REMOTE_INSTANCE_ID=* ]]; then
+        printf 'REPO_REMOTE_INSTANCE_ID=%s\n' "$id"
+      else
+        printf '%s\n' "$line"
+      fi
+    done <"$REPO_ENV" >"$tmp"
+    mv "$tmp" "$REPO_ENV"
+  else
+    printf 'REPO_REMOTE_INSTANCE_ID=%s\n' "$id" >>"$REPO_ENV"
+  fi
+}
+
+# Write/refresh the one-word SSH alias so the connection is `ssh repo-remote-<name>`.
+# Honors REPO_REMOTE_SSH_CONFIG (default ~/.ssh/config) so tests never touch a
+# real config. Echoes the alias name.
+write_ssh_alias() {  # <ip>
+  local ip="$1" alias="repo-remote-${NAME}"
+  local cfg="${REPO_REMOTE_SSH_CONFIG:-$HOME/.ssh/config}"
+  local key="${REPO_REMOTE_SSH_KEY:-~/.ssh/id_ed25519}"
+  local user="${REPO_REMOTE_SSH_USER:-ubuntu}"
+  [[ -z "$ip" ]] && { printf '%s' "$alias"; return 0; }
+
+  mkdir -p "$(dirname "$cfg")" 2>/dev/null || true
+  local tmp; tmp="$(mktemp)"
+  # Strip any prior block for this alias, then append a fresh one.
+  if [[ -f "$cfg" ]]; then
+    awk -v a="Host $alias" '
+      $0 == a {skip=1; next}
+      skip && /^Host / {skip=0}
+      skip {next}
+      {print}
+    ' "$cfg" >"$tmp"
+  fi
+  {
+    [[ -s "$tmp" ]] && printf '\n'
+    printf 'Host %s\n' "$alias"
+    printf '    HostName %s\n' "$ip"
+    printf '    User %s\n' "$user"
+    printf '    IdentityFile %s\n' "$key"
+  } >>"$tmp"
+  mv "$tmp" "$cfg"
+  chmod 600 "$cfg" 2>/dev/null || true
+  printf '%s' "$alias"
+}
+
+# ── result emitters ─────────────────────────────────────────────────────────
+emit_plan() {  # dry-run plan (no cloud mutation)
+  if [[ "$JSON_OUT" == true ]]; then
+    printf '{'
+    printf '"action":"plan",'
+    printf '"dry_run":true,'
+    printf '"provider":"%s",' "$(json_escape "$PROVIDER")"
+    printf '"name":"%s",' "$(json_escape "$NAME")"
+    printf '"instance_type":"%s",' "$(json_escape "$INSTANCE_TYPE")"
+    printf '"region":"%s",' "$(json_escape "$REGION")"
+    printf '"disk_gb":%s,' "$DISK_GB"
+    printf '"gpu":%s,' "$IS_GPU"
+    printf '"idle_shutdown_min":%s,' "$IDLE_MIN"
+    printf '"ssh_alias":"repo-remote-%s",' "$(json_escape "$NAME")"
+    printf '"estimated_hourly_cost_usd":%s,' "$COST_HOURLY"
+    printf '"estimated_cost_approximate":%s' "$COST_APPROX"
+    printf '}\n'
+  else
+    log "PLAN (dry run — nothing created; pass --yes to provision):"
+    log "  provider:            $PROVIDER"
+    log "  instance type:       $INSTANCE_TYPE${IS_GPU:+ (GPU)}"
+    log "  region/zone:         $REGION"
+    log "  disk:                ${DISK_GB} GB"
+    log "  idle shutdown:       ${IDLE_MIN} min"
+    log "  est. hourly cost:    \$${COST_HOURLY}/hr$([[ "$COST_APPROX" == true ]] && echo ' (approximate)')"
+    log "  ssh alias:           repo-remote-${NAME}"
+  fi
+}
+
+emit_up_result() {  # <id> <ip> <alias> <reused>
+  local id="$1" ip="$2" alias="$3" reused="$4"
+  if [[ "$JSON_OUT" == true ]]; then
+    printf '{'
+    printf '"action":"up",'
+    printf '"provider":"%s",' "$(json_escape "$PROVIDER")"
+    printf '"name":"%s",' "$(json_escape "$NAME")"
+    printf '"instance_id":"%s",' "$(json_escape "$id")"
+    printf '"public_ip":"%s",' "$(json_escape "$ip")"
+    printf '"ssh_alias":"%s",' "$(json_escape "$alias")"
+    printf '"instance_type":"%s",' "$(json_escape "$INSTANCE_TYPE")"
+    printf '"region":"%s",' "$(json_escape "$REGION")"
+    printf '"gpu":%s,' "$IS_GPU"
+    printf '"idle_shutdown_min":%s,' "$IDLE_MIN"
+    printf '"reused":%s,' "$reused"
+    printf '"estimated_hourly_cost_usd":%s,' "$COST_HOURLY"
+    printf '"estimated_cost_approximate":%s' "$COST_APPROX"
+    printf '}\n'
+  else
+    log "$([[ "$reused" == true ]] && echo reused || echo created) instance $id (${INSTANCE_TYPE}) @ ${ip:-<no public ip>}"
+    log "  ssh alias:        $alias"
+    log "  est. hourly cost: \$${COST_HOURLY}/hr$([[ "$COST_APPROX" == true ]] && echo ' (approximate)')"
+    log "  teardown:         repo-remote down --yes   (or /repo:remote --down)"
+  fi
+}
+
+emit_status_result() {  # <rows: id state type ip launch, tab/space separated per line>
+  local rows="$1"
+  if [[ "$JSON_OUT" == true ]]; then
+    printf '{"action":"status","provider":"%s","name":"%s","instances":[' \
+      "$(json_escape "$PROVIDER")" "$(json_escape "$NAME")"
+    local first=true line id state type ip launch
+    while IFS= read -r line; do
+      [[ -z "$line" ]] && continue
+      id="$(printf '%s' "$line" | awk '{print $1}')"
+      state="$(printf '%s' "$line" | awk '{print $2}')"
+      type="$(printf '%s' "$line" | awk '{print $3}')"
+      ip="$(printf '%s' "$line" | awk '{print $4}')"
+      launch="$(printf '%s' "$line" | awk '{print $5}')"
+      [[ "$ip" == "None" ]] && ip=""
+      [[ "$first" == true ]] && first=false || printf ','
+      printf '{"instance_id":"%s","state":"%s","instance_type":"%s","public_ip":"%s","launch_time":"%s"}' \
+        "$(json_escape "$id")" "$(json_escape "$state")" "$(json_escape "$type")" "$(json_escape "$ip")" "$(json_escape "$launch")"
+    done <<<"$rows"
+    printf ']}\n'
+  else
+    if [[ -z "$rows" ]]; then
+      log "no instances tagged repo-remote=${NAME}"
+    else
+      log "instances tagged repo-remote=${NAME}:"
+      printf '%s\n' "$rows" >&2
+    fi
+  fi
+}
+
+emit_down_result() {  # <ids> <disposition: noop|dry-run|stopped|terminated>
+  local ids="$1" disp="$2"
+  if [[ "$JSON_OUT" == true ]]; then
+    printf '{"action":"down","provider":"%s","name":"%s","disposition":"%s","instances":[' \
+      "$(json_escape "$PROVIDER")" "$(json_escape "$NAME")" "$(json_escape "$disp")"
+    local first=true id
+    for id in $ids; do
+      [[ "$first" == true ]] && first=false || printf ','
+      printf '"%s"' "$(json_escape "$id")"
+    done
+    printf ']}\n'
+  else
+    case "$disp" in
+      noop)     log "no instances tagged repo-remote=${NAME} to stop" ;;
+      dry-run)  log "DRY RUN — would stop$([[ "$DELETE" == true ]] && echo /terminate): $ids (pass --yes to act)" ;;
+      stopped)  log "stopped: $ids" ;;
+      terminated) log "terminated (disks removed): $ids" ;;
+    esac
+  fi
+}
+
+# ── argument parsing ────────────────────────────────────────────────────────
+usage() {
+  sed -n '4,60p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+}
+
+parse_args() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      up|status|down) [[ -z "$ACTION" ]] && ACTION="$1" || die 64 "multiple actions given ($ACTION, $1)" ;;
+      --status)       ACTION="status" ;;
+      --down)         ACTION="down" ;;
+      --yes|-y)       YES=true ;;
+      --json)         JSON_OUT=true ;;
+      --delete)       DELETE=true ;;
+      aws|gcp)        PROVIDER_ARG="$1" ;;
+      -h|--help)      usage; exit 0 ;;
+      *)              die 64 "unknown argument: $1 (see --help)" ;;
+    esac
+    shift
+  done
+  [[ -n "$ACTION" ]] || die 64 "no action given (expected: up | status | down; see --help)"
+}
+
+# ── main ────────────────────────────────────────────────────────────────────
+main() {
+  parse_args "$@"
+  resolve_paths
+  load_config
+  resolve_settings
+
+  case "$ACTION" in
+    up)
+      require_cost_config
+      if [[ "$YES" != true ]]; then
+        emit_plan          # dry-run: the plan (with cost) is shown, nothing spent
+        exit 0
+      fi
+      case "$PROVIDER" in
+        aws) aws_up ;;
+        gcp) gcp_up ;;
+        *)   die 2 "unknown provider '$PROVIDER'" ;;
+      esac
+      ;;
+    status)
+      [[ -n "$PROVIDER" ]] || die 2 "REPO_REMOTE_PROVIDER (or an aws|gcp argument) is required for status"
+      case "$PROVIDER" in
+        aws) aws_status ;;
+        gcp) gcp_status ;;
+        *)   die 2 "unknown provider '$PROVIDER'" ;;
+      esac
+      ;;
+    down)
+      [[ -n "$PROVIDER" ]] || die 2 "REPO_REMOTE_PROVIDER (or an aws|gcp argument) is required for down"
+      case "$PROVIDER" in
+        aws) aws_down ;;
+        gcp) gcp_down ;;
+        *)   die 2 "unknown provider '$PROVIDER'" ;;
+      esac
+      ;;
+  esac
+}
+
+main "$@"

--- a/skills/repo/SKILL.md
+++ b/skills/repo/SKILL.md
@@ -29,7 +29,7 @@ costs.
 | [[handoff]] | Roll the session safely — file follow-ups, reset, check for a CLI update, write a handoff note the next session reads first |
 | [[tidy]] | Tidy up — build artifacts, caches, temp files, empty dirs |
 | [[release]] | Cut a release — pre-flight, semver decision, CHANGELOG, version bump, tag, GitHub Release |
-| [[remote]] | Launch a cloud dev session (GCP or AWS) with this repo ready to go, then open SSH |
+| [[remote]] | Launch a cloud dev session (GCP or AWS) with this repo ready to go, then open SSH. Its provisioning contract is implemented once in `scripts/repo/repo-remote.sh` (installed to `.claude/skills/repo/scripts/`); the interactive flow delegates to that script, which also serves as a headless `repo-remote up --yes --json` entry point for non-interactive callers (e.g. loom's `fleet add-worker`) |
 | [[update-tools]] | Check installed tool packages (Loom, Anvil, …) against their sources and offer updates |
 | [[followups]] | Capture follow-on work from this session and file it as issues — here or in upstream tool repos, always confirmed first |
 | [[branches]] | Branch & worktree hygiene — merged PRs, orphaned branches, stale worktrees |

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -111,7 +111,7 @@ TARGET="$(cd "$TARGET" 2>/dev/null && pwd)" || error "Target directory does not 
   || { info "No Repo Skills install found in $TARGET"; exit 0; }
 
 echo "Will remove from $TARGET:"
-[[ -d "$TARGET/.claude/skills/repo" ]]   && echo "  .claude/skills/repo/ (incl. hooks/guard-destructive.sh, hooks/session-start-handoff.sh)"
+[[ -d "$TARGET/.claude/skills/repo" ]]   && echo "  .claude/skills/repo/ (incl. hooks/guard-destructive.sh, hooks/session-start-handoff.sh, scripts/repo-remote.sh)"
 [[ -d "$TARGET/.claude/commands/repo" ]] && echo "  .claude/commands/repo/"
 grep -qF "$MARKER_BEGIN" "$TARGET/CLAUDE.md" 2>/dev/null && echo "  CLAUDE.md REPO-SKILLS block"
 if [[ -f "$TARGET/.claude/settings.json" ]] && \


### PR DESCRIPTION
## Summary

Extracts the `/repo:remote` provisioning contract from prose (`commands/repo/remote.md`) into an executable, non-interactive script — `scripts/repo/repo-remote.sh` — so loom's `fleet add-worker` can drive provisioning programmatically instead of a Claude session hand-transcribing 450 lines of prose (as happened in the 2026-07-28 pilot). The interactive skill now **delegates** to this single implementation rather than re-issuing cloud CLI calls, so the headless and interactive paths cannot drift (the third acceptance criterion).

The seam produced, consumed by loom: "a reachable Ubuntu box, repo-remote SSH alias written, instance id recorded" — emitted as machine-readable JSON so a caller can implement loom's "plan shown before money is spent" rule.

## Changes

- **`scripts/repo/repo-remote.sh` (new)** — the non-interactive implementation: two-layer config loading (`~/.config/repo/remote.env` shared → repo `.env` overrides), provider dispatch (aws/gcp), `up [--yes] [--json]` / `status` / `down [--yes] [--delete]` (both verb and remote.md-style `--status`/`--down` flag forms), `repo-remote=<name>` tagging, idle-shutdown guard via cloud-init user-data, `REPO_REMOTE_INSTANCE_ID` write-back to the repo `.env`, SSH-alias write, GPU-family detection + Deep Learning AMI selection + `VcpuLimitExceeded` quota remediation, and JSON output (instance id, public IP, SSH alias, estimated hourly cost).
- **`commands/repo/remote.md`** — documents the headless entry point and rewires the interactive steps + `--status`/`--down` to delegate to the shared script instead of issuing cloud CLI calls from prose.
- **`install.sh` / `uninstall.sh`** — ships the script to consumer repos at `.claude/skills/repo/scripts/repo-remote.sh` (`chmod +x`), mirroring the hook-install pattern; dry-run enumeration and uninstall listing updated.
- **`commands/repo/tests/test-repo-remote.sh` (new)** — 71-case suite (mock `aws` CLI + fixtures) covering the cost gate, config-layer precedence, JSON shape, GPU cost, reuse, write-back, quota remediation, and the up/status/down flow, plus a doc-drift assertion against `remote.md` and a packaging assertion against `install.sh`. `hooks/repo/tests/run.sh` delegates to it.
- **`README.md` / `skills/repo/SKILL.md`** — write-footprint, repository-layout, and `[[remote]]` description updated.

## The cost-safety gate (highest cost of being wrong)

`--yes` removes the interactive prompt, **not** the consent requirement. `up` requires the provider, its credentials, and `REPO_REMOTE_INSTANCE_TYPE` to be present in config; a missing cost-relevant field is a loud `exit 2` failure — never a silent default that could pick a billable size. Plain `up` (no `--yes`) is a dry run that prints the plan + estimated cost and creates nothing. All of this is pinned by automated tests (missing-type, missing-creds, missing-provider, and `--yes`-still-requires-type cases).

## Acceptance Criteria Verification

- [x] Non-interactive invocation provisions (or reuses) end-to-end with zero prompts, failing loudly on missing config — verified end-to-end against a mock aws CLI (`up --yes --json`, reuse of pinned/tagged instances) and by the exit-2 cost-gate tests.
- [x] JSON output includes instance id, public IP, SSH alias, and estimated hourly cost — asserted in the "JSON output shape" test block.
- [x] Interactive skill and headless path share one implementation — remote.md rewired to delegate; doc-drift test asserts `remote.md` references `scripts/repo/repo-remote.sh` and documents the subcommands/flags.

## Test Plan

- [x] `pnpm test` — 603 cases pass (including the 71 new repo-remote cases); run.sh delegates to the new suite.
- [x] Install/uninstall round-trip into a scratch repo — script lands executable at `.claude/skills/repo/scripts/`, runs from there, no template-placeholder leaks, removed on uninstall.
- [ ] Manual verification against a real/sandboxed AWS account (requires credentials — an operator step; the automated suite exercises the same code paths against a mock CLI).

## Notes

- **GCP** is implemented along the same command surface (up/status/down, labels, startup-script idle guard, accelerator attach) but the end-to-end mock coverage focuses on AWS + the shared logic (config/cost gate/JSON), per the issue's "AWS first, GCP fast-follow" split guidance. GPU AMI selection and `VcpuLimitExceeded` remediation for AWS are implemented and tested, not deferred.

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)