### PR TITLE
fix(install): gate CLAUDE.md pointer on commands/ ignore state alone

### DIFF
--- a/hooks/repo/tests/test-install-claude-md-markers.sh
+++ b/hooks/repo/tests/test-install-claude-md-markers.sh
@@ -378,6 +378,62 @@ assert_bytes "reconcile non-adjacent: whole-line removal (historical behavior)" 
 
 # ---------------------------------------------------------------------------
 echo ""
+echo "-- install.sh gitignore gate: the pointer block is skipped only when commands/ is ignored --"
+
+# Mixed state (repo#51): commands/ tracked via a negation, skills/ still ignored.
+# The pointer advertises the /repo:* commands, which ARE committed here, so the
+# block MUST be written. An earlier OR'd probe (commands OR skills) wrongly
+# skipped it because skills/ is ignored.
+T12="$(new_target gitignore-mixed-commands-tracked)"
+printf '%s\n' '.claude/*' '!.claude/commands/' > "$T12/.gitignore"
+cat > "$T12/CLAUDE.md" <<'EOF'
+Project notes.
+
+<!-- BEGIN LOOM ORCHESTRATION -->
+Loom content.
+<!-- END LOOM ORCHESTRATION -->
+EOF
+
+# Sanity-check the fixture reproduces the reported split state before asserting
+# on install behavior: commands/ negated back in, skills/ still ignored.
+assert_eq       "gitignore mixed: commands/ is NOT ignored (negation resolved)" \
+                "1" "$(git -C "$T12" check-ignore -q .claude/commands/repo/help.md; echo $?)"
+assert_eq       "gitignore mixed: skills/ IS ignored" \
+                "0" "$(git -C "$T12" check-ignore -q .claude/skills/repo; echo $?)"
+
+OUT12="$(bash "$INSTALL_SH" -y "$T12" 2>&1)"; RC12=$?
+BODY12="$(slurp "$T12/CLAUDE.md")"
+assert_eq       "gitignore mixed: install exits 0" "0" "$RC12"
+assert_not_contains "gitignore mixed: does NOT skip the pointer block" \
+                "$OUT12" "skipping the CLAUDE.md pointer block"
+assert_contains "gitignore mixed: reports the append"     "$OUT12" "Appended REPO-SKILLS block to CLAUDE.md"
+assert_contains "gitignore mixed: REPO-SKILLS block IS written" \
+                "$BODY12" "<!-- BEGIN REPO-SKILLS -->"
+
+# Fully gitignored (`.claude/`): commands/ is machine-local, so a committed
+# pointer would advertise uncommitted command files. The block MUST be skipped.
+T13="$(new_target gitignore-fully-ignored)"
+printf '%s\n' '.claude/' > "$T13/.gitignore"
+cat > "$T13/CLAUDE.md" <<'EOF'
+Project notes.
+
+<!-- BEGIN LOOM ORCHESTRATION -->
+Loom content.
+<!-- END LOOM ORCHESTRATION -->
+EOF
+BEFORE13="$(slurp "$T13/CLAUDE.md")"
+
+OUT13="$(bash "$INSTALL_SH" -y "$T13" 2>&1)"; RC13=$?
+BODY13="$(slurp "$T13/CLAUDE.md")"
+assert_eq       "gitignore fully: install exits 0" "0" "$RC13"
+assert_contains "gitignore fully: skips the pointer block" \
+                "$OUT13" "skipping the CLAUDE.md pointer block"
+assert_not_contains "gitignore fully: no REPO-SKILLS block written" \
+                "$BODY13" "<!-- BEGIN REPO-SKILLS -->"
+assert_eq       "gitignore fully: CLAUDE.md untouched" "$BEFORE13" "$BODY13"
+
+# ---------------------------------------------------------------------------
+echo ""
 echo "-- guard: unresolvable marker layouts are refused, never guessed --"
 
 T9="$(new_target guard-unterminated)"

--- a/install.sh
+++ b/install.sh
@@ -490,20 +490,32 @@ fi
 
 CLAUDE_MD="$TARGET/CLAUDE.md"
 
-# If the install destination is gitignored in the target, the command/skill
-# files we just wrote are effectively machine-local (they won't be committed),
-# so a tracked CLAUDE.md pointer would advertise /repo:* commands whose files
-# aren't in the repo. Mirror dev mode here: skip the CLAUDE.md block entirely.
-# Probe each destination separately (check-ignore -q accepts only one pathname)
-# and skip if *either* is ignored, since a split state is itself broken. The
-# probe exits non-zero outside a git repo or when nothing is ignored, which
-# correctly falls through to the write path.
+# If the commands destination is gitignored in the target, the command files we
+# just wrote are effectively machine-local (they won't be committed), so a
+# tracked CLAUDE.md pointer would advertise /repo:* commands whose files aren't
+# in the repo. Mirror dev mode here: skip the CLAUDE.md block entirely.
+#
+# Gate the decision on the commands destination *alone*, not commands OR skills.
+# The pointer block exists to advertise the /repo:* commands ("The /repo:*
+# commands still work in-session"), so what matters is whether those command
+# files are committed. A split state where commands/ is tracked (e.g. via a
+# `!.claude/commands/` negation) but skills/ is gitignored is legitimate — the
+# pointer is still correct because the commands it advertises are committed. An
+# earlier version OR'd both probes and wrongly skipped the pointer in that mixed
+# state (see issue #51). The `.claude/skills/repo/SKILL.md` reference in the
+# block degrades gracefully if skills/ is machine-local: only the link goes
+# stale, the commands still work.
+#
+# Probe a representative *file* path rather than the bare directory so git's
+# ignore resolution (including `!` negations and nested .gitignore files) is
+# evaluated the same way it would be for a real committed file. check-ignore -q
+# exits non-zero outside a git repo or when nothing is ignored, which correctly
+# falls through to the write path.
 dest_is_gitignored() {
-  git -C "$TARGET" check-ignore -q .claude/commands/repo 2>/dev/null \
-    || git -C "$TARGET" check-ignore -q .claude/skills/repo 2>/dev/null
+  git -C "$TARGET" check-ignore -q .claude/commands/repo/help.md 2>/dev/null
 }
 if dest_is_gitignored; then
-  warning "Install destination (.claude/commands, .claude/skills) is gitignored in $TARGET;"
+  warning "Install destination (.claude/commands) is gitignored in $TARGET;"
   warning "skipping the CLAUDE.md pointer block (a committed pointer to uncommitted command"
   warning "files is not what you want). The /repo:* commands still work in-session."
   reconcile_orphaned_block


### PR DESCRIPTION
## Summary

`install.sh`'s `dest_is_gitignored()` OR'd two `git check-ignore` probes (`commands/` OR `skills/`), so a legitimate split state wrongly skipped the CLAUDE.md pointer block. In a repo with:

```
.claude/*
!.claude/commands/
```

`commands/` is tracked (negated back in) but `skills/` is still ignored by `.claude/*`. The OR tripped on `skills/` and skipped the pointer — even though the `/repo:*` commands the pointer advertises are committed, making the pointer correct. Observed installing Repo Skills 0.6.1 into rjwalters/claude-monitor.

Per the Curator's recommended Option A, the skip decision now gates on the **commands** destination alone (that is what makes `/repo:*` work from a fresh clone), and probes a representative *file* path (`.claude/commands/repo/help.md`) so git resolves `!` negations and nested `.gitignore` files exactly as it would for a real committed file. The `skills/repo/SKILL.md` reference in the block degrades gracefully when `skills/` is machine-local (only the link goes stale).

## Changes

- `install.sh` — `dest_is_gitignored()` now probes `.claude/commands/repo/help.md` alone instead of OR-ing the commands and skills directory paths; comment rewritten to explain the split-state rationale; skip warning text narrowed to `.claude/commands`.
- `hooks/repo/tests/test-install-claude-md-markers.sh` — new "gitignore gate" section: a mixed-state repo (`.claude/*` + `!.claude/commands/`) asserts the REPO-SKILLS block **is** written; a fully-gitignored (`.claude/`) repo asserts it is still **skipped** (no regression).

## Acceptance Criteria Verification

- [x] Uses `git check-ignore` on a representative file path (`.claude/commands/repo/help.md`) rather than pattern-matching the directory.
- [x] Mixed state handled: commands tracked but skills gitignored -> pointer block still written. Verified by the new automated test and a manual `git init` reproduction of the reported gitignore.
- [x] Regression test: repo with `.claude/*` + `!.claude/commands/` gets the pointer block installed.
- [x] Fully-gitignored case still correctly skips the block (no regression).

## Test Plan

- `bash hooks/repo/tests/test-install-claude-md-markers.sh` -> 59/59 pass (10 new cases).
- `CI=true pnpm test` -> 756/756 pass, 0 fail.
- Manual reproduction: `git init` a scratch repo with the two-line gitignore, `install.sh -y` -> "Appended REPO-SKILLS block to CLAUDE.md" and the block is present.

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)