### PR TITLE
docs(changelog): announce CLAUDE.md marker refusal conditions from #42

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Changelog
 
+## Unreleased
+
+- **CLAUDE.md marker surgery is now anchored to the marker string, closing a
+  data-loss bug (#38, PR #42).** Previously `install.sh`/`uninstall.sh` bounded
+  the REPO-SKILLS block by whole physical lines, so when `<!-- END REPO-SKILLS
+  -->` shared one line with an adjacent tool's `<!-- BEGIN … -->`, block removal
+  could silently delete that neighbouring tool's marker block. Removal now
+  anchors to the marker **substring** and a validation guard
+  (`claude_md_block_validate`) gates every rewrite.
+- **New refusal conditions (user-visible behavior change).** The guard refuses
+  to rewrite — and, in `install.sh`, exits non-zero — when the marker layout is
+  unresolvable: the `<!-- BEGIN REPO-SKILLS -->` count is not exactly 1, the
+  `<!-- END REPO-SKILLS -->` count is not exactly 1, or the END marker appears
+  before the BEGIN marker. On refusal, CLAUDE.md is left byte-for-byte untouched
+  and the warning names the offending condition. This is deliberate: the repo
+  applies safe fixes automatically and gates destructive ones rather than
+  guessing at an ambiguous layout. **Installs that previously proceeded (mangling
+  or no-op'ing) against such a CLAUDE.md now fail loudly instead.**
+- **Known limitation — quoting the markers as prose or in a code fence now
+  triggers a refusal.** Marker counting is substring-based, so a consumer
+  CLAUDE.md that *mentions* `<!-- BEGIN REPO-SKILLS -->` (documenting the
+  convention, or pasting an example inside a code fence) counts as a duplicate
+  marker and its install fails with exit 1. Fence-aware detection is
+  intentionally **not** implemented — it would reintroduce the ambiguity-guessing
+  #42 removed. If you need to show the markers as an example, alter them so they
+  are not literal occurrences (e.g. a non-ASCII hyphen, `BEGIN REPO‑SKILLS`, or a
+  broken-up string).
+- **A refusal from `reconcile_orphaned_block` leaves a partial install.** That
+  refusal path (and the update path) fires *after* skills and commands have
+  already been installed, so a refused run is a partial install — the warning
+  already says "(skills and commands were installed)". The remedy is not to
+  assume nothing was written: **correct the markers so exactly one BEGIN and one
+  END exist, in that order, then re-run the installer** (which reconciles the
+  now-valid block). CLAUDE.md itself is never modified by a refused run.
+
 ## 0.6.1 (2026-07-27)
 
 - **`install.sh` now reconciles an orphaned CLAUDE.md pointer block (#31).**


### PR DESCRIPTION
## Summary

Adds an `## Unreleased` section to `CHANGELOG.md` announcing the user-visible behavior change introduced by PR #42 (issue #38). PR #42 fixed a real data-loss bug (whole-line marker surgery could delete an adjacent tool's marker block) by anchoring block surgery to the marker string and adding a validation guard — but the guard **widens the set of inputs that now hard-fail an install**, and that was undocumented. This PR documents it so people learn it from a release note rather than a broken install.

## Changes

- `CHANGELOG.md`: new `## Unreleased` section covering all four acceptance-criteria points:
  - **(a)** the data-loss fix (marker-string-anchored surgery + validation guard).
  - **(b)** the three new refusal conditions (BEGIN count ≠ 1, END count ≠ 1, END before BEGIN).
  - **(c)** the known limitation — a CLAUDE.md quoting the markers as prose or in a code fence now counts as a duplicate marker and is refused; fence-aware detection is intentionally **not** built (documented as a limitation with a workaround: alter the literal marker, e.g. a non-ASCII hyphen).
  - **(d)** a refusal from `reconcile_orphaned_block` leaves a **partial** install (skills/commands already written), with the remedy stated plainly: fix the markers to exactly one ordered BEGIN/END pair, then re-run.

## Scope note (this wave)

Per my dispatch instructions, this PR is **scoped to changelog/release docs only**. The issue's Curator-listed affected files also include `install.sh`, `uninstall.sh`, and `hooks/repo/tests/test-install-claude-md-markers.sh` — those are owned by other builders this wave, so they are intentionally **not** touched here:

- **`install.sh` / `uninstall.sh` inline-remedy wording** (AC item 3, at `install.sh:84-87`/`522-526` and `uninstall.sh:150`) — deferred; the release note already states the remedy so an affected user has a documented path even before the message wording lands.
- **T12 out-of-order guard test** (the END-before-BEGIN branch at `lib/claude-md-block.sh:101-104` has no test) — deferred to the builder owning the test file this wave. The existing marker suite (49 cases) still passes.

## Release-mechanism finding (for the release driver)

The Curator asked me to verify whether `/repo:release` folds an existing `## Unreleased` section into the next version heading. It does **not**: Phase 4 drafts a fresh entry from the `<prev-tag>..<tag>` git-log range and Phase 5 inserts it at the top of `CHANGELOG.md` — there is no logic that merges an `## Unreleased` block. **The release driver must fold this `## Unreleased` section into the next version heading by hand** so points (a)-(d) survive into the tagged release note. The Phase 1.5 completeness gate is **not** confused by the heading — it greps only for `^## v?[version]` tag headers, and `Unreleased` matches no tag, so it is neither flagged MISSING nor mismatched. Latest tag is v0.6.1 and the #42 fix is not yet tagged, so this note can still ship *with* the behavior change.

## Test Plan

- [x] `CI=true pnpm test` from the worktree — **PASS: 746, FAIL: 0** (includes `test-install-claude-md-markers.sh` 49/49).
- [x] `## Unreleased` entry covers all four points (a)-(d) and states the remedy.
- [x] Scope check: only `CHANGELOG.md` modified (`git diff --stat` = 1 file, 35 insertions).
- [x] Verified `/repo:release` Phase 1.5 gate greps tag version headers only (no `Unreleased` confusion).

Closes #45