### PR TITLE
test(branches): skip merge-tree assertions on git < 2.38 and cover the fallback

### DIFF
--- a/commands/repo/branches.md
+++ b/commands/repo/branches.md
@@ -154,6 +154,7 @@ already merged. Decide with **content containment**, not SHA ancestry:
 
 ```bash
 # Would merging the branch into <default> change anything at all?
+# `--write-tree` requires git >= 2.38; on older git this errors and you take the fallback below.
 [ "$(git merge-tree --write-tree <default> <branch>)" = "$(git rev-parse '<default>^{tree}')" ]
 ```
 

--- a/commands/repo/tests/test-branches-loss-check.sh
+++ b/commands/repo/tests/test-branches-loss-check.sh
@@ -33,10 +33,12 @@ RESET_MD="$REPO_ROOT/commands/repo/reset.md"
 
 PASS=0
 FAIL=0
+SKIP=0
 TOTAL=0
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
 NC='\033[0m'
 
 if [[ ! -f "$BRANCHES_MD" ]]; then
@@ -58,6 +60,17 @@ ok() {   # <label>
 no() {   # <label> <detail>
     TOTAL=$((TOTAL + 1)); FAIL=$((FAIL + 1))
     printf "  ${RED}FAIL${NC}: %s\n" "$1"
+    [[ -n "${2:-}" ]] && printf "        %s\n" "$2"
+    return 0
+}
+# A skipped assertion is neither pass nor fail: the environment cannot exercise
+# it (e.g. this git predates `merge-tree --write-tree`). It is counted separately
+# and surfaced in the summary so a silently-skipped suite is never mistaken for a
+# full pass (repo#46). SKIP does NOT feed TOTAL/PASS/FAIL — run.sh folds only the
+# pass/fail counts, and reports the skip count as a breakdown annotation.
+skip() {  # <label> <reason>
+    SKIP=$((SKIP + 1))
+    printf "  ${YELLOW}SKIP${NC}: %s\n" "$1"
     [[ -n "${2:-}" ]] && printf "        %s\n" "$2"
     return 0
 }
@@ -213,6 +226,17 @@ build_fixtures() {
     echo mainonly > "$REPO/m.txt"
     git -C "$REPO" add -A && git -C "$REPO" commit -qm "MAINONLY: committed only to main"
     MAINONLY_SHA=$(git -C "$REPO" rev-parse --short HEAD)
+
+    # (6) IDENTICAL-TREE branch: same content as main's current tip but a
+    #     distinct SHA (an amended commit, same tree + same parent). Its tree
+    #     equals main's, so even the degraded `git diff --quiet` fallback can
+    #     prove containment — this is the legitimate "old git still classifies
+    #     SAFE" path exercised by the degraded-mode section below (repo#46).
+    #     Built last so main's tree is fixed from here on; leaving main checked
+    #     out keeps every later assertion operating from main.
+    git -C "$REPO" checkout -q -b feature/identical
+    git -C "$REPO" commit -q --amend --allow-empty -m "identical: main's tree, distinct SHA"
+    git -C "$REPO" checkout -q main
 }
 
 echo "branches.md permanent-loss check test suite"
@@ -220,6 +244,46 @@ echo "==========================================="
 echo ""
 
 build_fixtures
+
+# ---------------------------------------------------------------------------
+# Capability probe + merge-tree shim (repo#46)
+# ---------------------------------------------------------------------------
+# 5b's primary containment check uses `git merge-tree --write-tree`, which only
+# exists on git >= 2.38. Probe the capability once — on the fixture repo, not by
+# parsing `git --version` (a vendor version string can distort that) — so the
+# assertions that need a REAL merge-tree result skip cleanly on older git instead
+# of failing with a confusing empty-string-vs-tree-hash mismatch. The documented
+# fallback (`git diff --quiet` -> merged-PR lookup) is then exercised explicitly
+# under a PATH shim below, on every git version.
+HAS_MERGE_TREE=0
+if git -C "$REPO" merge-tree --write-tree HEAD HEAD >/dev/null 2>&1; then
+    HAS_MERGE_TREE=1
+fi
+
+# A `git` shim that simulates git < 2.38: it fails only on `merge-tree` and execs
+# the real git for everything else. Used by mt_unsupported_loss_check to force
+# the degraded fallback chain regardless of the host git version.
+SHIM_DIR="$SCRATCH/nomergetree-bin"
+mkdir -p "$SHIM_DIR"
+REAL_GIT="$(command -v git)"
+cat > "$SHIM_DIR/git" <<SHIM
+#!/usr/bin/env bash
+for arg in "\$@"; do
+    if [ "\$arg" = "merge-tree" ]; then
+        echo "git: 'merge-tree --write-tree' unsupported (simulated git < 2.38)" >&2
+        exit 129
+    fi
+done
+exec "$REAL_GIT" "\$@"
+SHIM
+chmod +x "$SHIM_DIR/git"
+
+# loss_check run against a git that lacks `merge-tree --write-tree`. The PATH
+# override lives in a subshell, so the real merge-tree is untouched afterward —
+# later real-git assertions must not see the shim (guards the "shim leak" case).
+mt_unsupported_loss_check() {  # <branch>
+    ( PATH="$SHIM_DIR:$PATH"; loss_check "$1" )
+}
 
 # ---------------------------------------------------------------------------
 echo "-- the bug: \`--not\` is a toggle (repo#39) --"
@@ -248,17 +312,31 @@ if [[ -n "$SQ_5A" ]]; then
 else
     no "5a alone reports the squash-merged branch as having unique SHAs" "5a was empty"
 fi
-# ...but its content IS contained in main, which is what 5b measures.
-MT=$(git -C "$REPO" merge-tree --write-tree main feature/squashed 2>/dev/null)
-assert_eq "5b: merging the squash-merged branch changes nothing" \
-    "$(git -C "$REPO" rev-parse 'main^{tree}')" "$MT"
+# ...but its content IS contained in main, which is what 5b measures. This direct
+# probe needs a real merge-tree result, so it skips (not fails) on git < 2.38.
+if [[ "$HAS_MERGE_TREE" == 1 ]]; then
+    MT=$(git -C "$REPO" merge-tree --write-tree main feature/squashed 2>/dev/null)
+    assert_eq "5b: merging the squash-merged branch changes nothing" \
+        "$(git -C "$REPO" rev-parse 'main^{tree}')" "$MT"
+else
+    skip "5b: merging the squash-merged branch changes nothing" \
+        "git merge-tree --write-tree unsupported (git < 2.38)"
+fi
 
 # ---------------------------------------------------------------------------
 echo ""
 echo "-- fixture 1: squash-merged branch classifies SAFE --"
 # ---------------------------------------------------------------------------
 PR_LOOKUP_MODE="none"   # no forge help at all — content containment must carry it
-assert_eq "squash-merged -> SAFE (without any PR lookup)" "SAFE" "$(loss_check feature/squashed)"
+# main has advanced past the squash-merge (later fixtures added files), so only
+# merge-tree can prove containment here; without it the degraded path correctly
+# refuses SAFE. That degraded direction is pinned in the fallback section below.
+if [[ "$HAS_MERGE_TREE" == 1 ]]; then
+    assert_eq "squash-merged -> SAFE (without any PR lookup)" "SAFE" "$(loss_check feature/squashed)"
+else
+    skip "squash-merged -> SAFE (without any PR lookup)" \
+        "content containment needs merge-tree; degraded path covered by the fallback section"
+fi
 
 # ---------------------------------------------------------------------------
 echo ""
@@ -269,7 +347,12 @@ assert_eq "unpushed work -> UNSAFE" "UNSAFE" "$(loss_check feature/unpushed)"
 # Not rescued by a bogus merged-PR answer being absent, and not by --prune.
 SAFE_SET="$(safe_to_delete_set | tr '\n' ' ')"
 assert_not_contains "unpushed branch is never offered for deletion" "$SAFE_SET" "feature/unpushed"
-assert_contains "squash-merged branch IS offered for deletion" "$SAFE_SET" "feature/squashed"
+if [[ "$HAS_MERGE_TREE" == 1 ]]; then
+    assert_contains "squash-merged branch IS offered for deletion" "$SAFE_SET" "feature/squashed"
+else
+    skip "squash-merged branch IS offered for deletion" \
+        "needs merge-tree to prove containment after main advanced (git < 2.38)"
+fi
 
 # ---------------------------------------------------------------------------
 echo ""
@@ -297,8 +380,13 @@ assert_eq "no merged PR found -> UNSAFE" "UNSAFE" "$(loss_check feature/pr-merge
 
 # A failing forge lookup must never rescue, nor condemn-to-SAFE, anything.
 PR_LOOKUP_MODE="fail"
-assert_eq "forge failure leaves squash-merged branch SAFE on content alone" \
-    "SAFE" "$(loss_check feature/squashed)"
+if [[ "$HAS_MERGE_TREE" == 1 ]]; then
+    assert_eq "forge failure leaves squash-merged branch SAFE on content alone" \
+        "SAFE" "$(loss_check feature/squashed)"
+else
+    skip "forge failure leaves squash-merged branch SAFE on content alone" \
+        "content containment needs merge-tree (git < 2.38)"
+fi
 assert_not_safe "forge failure keeps unpushed branch out of SAFE" \
     "$(loss_check feature/unpushed)"
 SAFE_SET="$(safe_to_delete_set | tr '\n' ' ')"
@@ -312,6 +400,57 @@ PR_LOOKUP_MODE="merged"
 assert_eq "unknown ref -> KEEP even with a merged-PR answer available" \
     "KEEP" "$(loss_check no/such/branch)"
 PR_LOOKUP_MODE="none"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "-- degraded path: git < 2.38 has no \`merge-tree --write-tree\` (repo#46) --"
+# ---------------------------------------------------------------------------
+# The documented fallback chain (branches.md:161) is `merge-tree` -> `git diff
+# --quiet` -> merged-PR lookup. On a modern git the merge-tree arm always wins, so
+# the fallback arms have zero natural coverage. Force them by running loss_check
+# under a git that fails on merge-tree, and pin the failure DIRECTION: the
+# degraded path must never classify SAFE unless containment is otherwise proven
+# (identical trees or a merged PR). "Degrades to SAFE" is precisely the
+# silent-data-loss failure repo#39 was filed to prevent — this is the coverage it
+# left untested. Runs on every git version; the shim forces the fallback.
+
+# (a) Identical trees: `git diff --quiet` exits 0 — the legitimate degraded
+#     success path (exit 0 is documented proof of containment).
+PR_LOOKUP_MODE="none"
+assert_eq "fallback: identical-tree branch -> SAFE via \`git diff --quiet\`" \
+    "SAFE" "$(mt_unsupported_loss_check feature/identical)"
+
+# (b) main advanced past a squash-merge, no forge help: diff differs, PR lookup
+#     finds nothing -> UNSAFE. The primary (merge-tree) path calls this SAFE;
+#     degraded correctly will not, because it cannot prove containment.
+PR_LOOKUP_MODE="none"
+assert_eq "fallback: squash-merged (main advanced), no PR -> UNSAFE" \
+    "UNSAFE" "$(mt_unsupported_loss_check feature/squashed)"
+assert_not_safe "fallback: squash-merged branch never degrades to SAFE" \
+    "$(mt_unsupported_loss_check feature/squashed)"
+
+# (c) Same, but the forge lookup itself fails (5c) -> KEEP, never SAFE.
+PR_LOOKUP_MODE="fail"
+assert_eq "fallback: squash-merged (main advanced), forge down -> KEEP" \
+    "KEEP" "$(mt_unsupported_loss_check feature/squashed)"
+
+# (d) A merged PR still rescues a branch without merge-tree — the forge arm is
+#     independent of the containment probe.
+PR_LOOKUP_MODE="merged"
+assert_eq "fallback: merged-PR lookup clears the branch without merge-tree" \
+    "SAFE" "$(mt_unsupported_loss_check feature/pr-merged)"
+PR_LOOKUP_MODE="none"
+
+# Shim hygiene: the PATH override was confined to subshells, so a REAL merge-tree
+# (when the host has one) must still resolve here — no leak into later cases.
+if [[ "$HAS_MERGE_TREE" == 1 ]]; then
+    if git -C "$REPO" merge-tree --write-tree main feature/squashed >/dev/null 2>&1; then
+        ok "merge-tree shim did not leak into the real environment"
+    else
+        no "merge-tree shim did not leak into the real environment" \
+            "real merge-tree unavailable after the shim subshells"
+    fi
+fi
 
 # ---------------------------------------------------------------------------
 echo ""
@@ -365,6 +504,7 @@ echo "========================================="
 echo "  Total:  $TOTAL"
 printf "  ${GREEN}Passed${NC}: %s\n" "$PASS"
 printf "  ${RED}Failed${NC}: %s\n" "$FAIL"
+printf "  ${YELLOW}Skipped${NC}: %s\n" "$SKIP"
 echo "========================================="
 
 if [[ $FAIL -gt 0 ]]; then

--- a/hooks/repo/tests/run.sh
+++ b/hooks/repo/tests/run.sh
@@ -345,6 +345,13 @@ else
     BL_STATUS=$?
     BL_PASS="$(suite_count Passed "$BL_OUT")"
     BL_FAIL="$(suite_count Failed "$BL_OUT")"
+    # This suite skips its merge-tree-dependent assertions on git < 2.38 (repo#46).
+    # Surface the skip count so a skipped-heavy run is visibly distinct from a full
+    # pass in the breakdown — skips are neither pass nor fail, so they do NOT feed
+    # the PASS/FAIL folding or the breakdown-sums-to-headline self-check.
+    BL_SKIP="$(suite_count Skipped "$BL_OUT")"
+    BL_NOTE="branches.md loss check"
+    [[ "$BL_SKIP" =~ ^[0-9]+$ && "$BL_SKIP" -gt 0 ]] && BL_NOTE+=" — $BL_SKIP skipped"
     if ! [[ "$BL_PASS" =~ ^[0-9]+$ && "$BL_FAIL" =~ ^[0-9]+$ ]]; then
         # Summary block missing or unparseable (e.g. the suite died early under
         # its own `set -e`). Never let that fold in as zero failures.
@@ -363,7 +370,7 @@ else
     fi
     PASS=$((PASS + BL_PASS))
     FAIL=$((FAIL + BL_FAIL))
-    record_suite "test-branches-loss-check.sh" "$BL_PASS" "$BL_FAIL" "branches.md loss check"
+    record_suite "test-branches-loss-check.sh" "$BL_PASS" "$BL_FAIL" "$BL_NOTE"
 fi
 
 # remote.md's provisioning contract is extracted into scripts/repo/repo-remote.sh


### PR DESCRIPTION
## Summary

The `test-branches-loss-check.sh` suite hard-failed on git < 2.38 and never covered the documented `merge-tree` fallback. The direct `git merge-tree --write-tree` probe swallowed the "unsupported" error under `2>/dev/null`, leaving an empty string that was then asserted against a tree hash — a confusing failure on exactly the git versions the fallback exists to support. Worse, the degraded path (`git diff --quiet` -> merged-PR lookup) had **zero** coverage, so the loss check's most dangerous failure mode — degrading to SAFE and silently deleting work (#39) — was untested.

This change makes the suite green on older git via a capability probe + skips, and adds git-version-independent positive coverage of the fallback chain that pins its failure direction (never SAFE unless containment is otherwise proven).

## Changes

- **Capability probe (not version parsing):** probe `merge-tree --write-tree` once on the fixture repo. The four assertions that need a real merge-tree result now `SKIP` with a reason instead of failing on git < 2.38.
- **Degraded-path coverage:** a new section forces the fallback chain via a subshell-scoped PATH shim (a `git` wrapper that fails only on `merge-tree`, execs real git otherwise) and asserts:
  - identical trees -> `SAFE` via `git diff --quiet` (legitimate degraded success);
  - main-advanced squash-merge, no PR -> `UNSAFE` (never SAFE);
  - same, forge lookup down -> `KEEP` (never SAFE);
  - a merged PR still clears the branch without merge-tree.
  A new `feature/identical` fixture (amended commit: main's tree, distinct SHA) drives the `diff --quiet` success arm. A hygiene assertion confirms the shim never leaks into later real-git cases.
- **Skip accounting:** a `Skipped: N` summary line in the suite; `run.sh` parses it and annotates the per-suite breakdown row (`— N skipped`) so a skipped run is visibly distinct from a full pass. Skips do not feed the pass/fail folding or the breakdown-sums-to-headline self-check (#44).
- **Docs:** one line in `branches.md` noting `--write-tree` requires git >= 2.38.

## Acceptance Criteria Verification

- [x] Suite detects `merge-tree --write-tree` support up front (probe on the fixture repo).
- [x] On unsupported git the merge-tree-dependent assertions skip with a clear message; `pnpm test` stays green (verified under a merge-tree-failing shim: suite exits 0, 4 skips).
- [x] Positive fallback coverage asserts the classification is KEEP/UNSAFE, never SAFE, when containment can't be proven.
- [x] Skip count surfaced in both the suite summary and the run.sh breakdown row.
- [x] `branches.md` states the minimum git version next to the command.

## Test Plan

- [x] Modern git (2.55.0): `pnpm test` -> 752 pass, 0 fail; branches suite 37 pass, **0 skipped**.
- [x] Simulated git < 2.38 (whole suite under a `merge-tree`-failing PATH shim): suite exits 0, 32 pass, **4 skipped**; run.sh breakdown row shows `branches.md loss check — 4 skipped`.
- [x] Fault injection: flipped the `no PR -> UNSAFE` fallback expectation to `SAFE`; suite went red naming the case (exit 1); reverted -> green.
- [x] Standalone run (`bash commands/repo/tests/test-branches-loss-check.sh`) works outside `pnpm test`.
- [x] Shim scoping: subshell-confined PATH; the "shim did not leak" assertion passes, later real-git assertions unaffected.

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)