### PR TITLE
feat(install): add opt-in shell claude wrapper surfacing pending handoff notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,25 @@ Installing Repo Skills also wires a **SessionStart hook** (`session-start-handof
 
 It is strictly read-only: it never writes or deletes the note (absorbing it and removing it is `/repo:handoff`'s own one-shot contract), it stays silent when no note exists, and it fails open, so a hook error can never block session start. It deliberately does not fire on `/clear`, which is not a process relaunch.
 
+### Optional: surface the note to the human too (`--shell-wrapper`)
+
+The `SessionStart` hook above gets the note into **Claude's** context. It shows the **human** nothing before the session starts — you quit, relaunch, and there's no visible signal that the previous session left instructions. Pass `--shell-wrapper` to `install.sh` to also opt into a shell `claude` wrapper that prints a compact banner (note path, age, a `##`-header outline, and a STALE warning past seven days) *before* Claude starts.
+
+This is the **one thing the installer writes outside the target repo** — it edits your shell rc (`~/.zshrc` or `~/.bashrc`, detected from `$SHELL`/`$ZSH_VERSION`/`$BASH_VERSION`; fish isn't supported yet and is skipped with a clear message rather than half-supported) — so it is treated with more care than everything else installed:
+
+- **Off by default.** `--yes`/non-interactive installs are a **strict no-op** for this feature unless `--shell-wrapper` is also passed — the rc file is neither read nor written. An interactive install without the flag still *offers* it via a confirm (default **N**), always showing the exact pending diff first.
+- **Marker-bounded and idempotent**, same convention as the `CLAUDE.md` block (`# BEGIN REPO-SKILLS CLAUDE WRAPPER` / `# END …`) — re-running `--shell-wrapper` replaces the block in place rather than duplicating it.
+- **Backed up before every edit.** The path is reported after install/uninstall.
+- **Preserves an existing `claude` alias.** If your rc already has `alias claude='command claude --dangerously-skip-permissions'` (or similar), its flags are folded into the new function and `unalias claude` runs ahead of the function definition so the two don't fight over which wins. Your original alias line is left untouched outside the markers. Anything outside that common single-line form is left alone with a message rather than guessed at.
+- **Never recurses and never breaks non-interactive invocations.** The function always calls `command claude`, and always falls through to it unmodified — the banner helper is skipped (not fatal) if it's ever missing, so scripted calls like `claude mcp list` behave exactly like the real binary.
+
+```bash
+./install.sh --shell-wrapper ~/projects/my-app       # interactive: offers a confirm either way
+./install.sh -y --shell-wrapper ~/projects/my-app    # non-interactive opt-in, no prompt
+```
+
+`uninstall.sh` removes the block (from both `~/.zshrc` and `~/.bashrc`, whichever has it) automatically, with the same backup discipline, and is a no-op if it was never installed.
+
 ## Installation
 
 The installer copies the skill files into a target repository's `.claude/` directory, wires the guard hook into `.claude/settings.json`, and appends a marker-bounded section to its `CLAUDE.md`.
@@ -64,6 +83,10 @@ The installer copies the skill files into a target repository's `.claude/` direc
 
 # Dev mode: symlink source files for live editing (dogfooding)
 ./install.sh --dev .
+
+# Opt into the shell `claude` wrapper (see "Optional: surface the note to the
+# human too" above) — off by default, edits your shell rc
+./install.sh --shell-wrapper ~/projects/my-app
 ```
 
 To remove: `./uninstall.sh /path/to/target-repo`.
@@ -83,6 +106,8 @@ The installer is designed to coexist with whatever already lives in the consumer
 
 Nothing else in the target repository is read or modified.
 
+Opt-in only, and outside the target repository: with `--shell-wrapper`, your shell rc (`~/.zshrc` or `~/.bashrc`) gains one marker-bounded block (`# BEGIN REPO-SKILLS CLAUDE WRAPPER` / `# END …`), backed up first — see "Optional: surface the note to the human too" above.
+
 ## Repository layout
 
 ```
@@ -95,11 +120,13 @@ hooks/repo/tests/run.sh      Smoke suite covering both hooks (bash, no framework
 hooks/repo/tests/test-guard-destructive.sh  Full guard regression suite (ported from Loom)
 hooks/repo/tests/test-session-start-handoff.sh  Handoff-hook suite (run.sh delegates to it)
 hooks/repo/tests/test-install-claude-md-markers.sh  CLAUDE.md marker-block regression suite
+hooks/repo/tests/test-shell-wrapper.sh  claude shell wrapper suite (run.sh delegates to it)
 commands/repo/tests/test-branches-loss-check.sh  branches.md permanent-loss check suite (run.sh delegates)
 commands/repo/tests/test-repo-remote.sh  repo-remote.sh provisioning-contract suite (run.sh delegates)
 install.sh                   Installer
 uninstall.sh                 Uninstaller
 lib/claude-md-block.sh       Marker-bounded CLAUDE.md surgery shared by install.sh/uninstall.sh
+lib/shell-wrapper.sh         Opt-in claude shell wrapper (--shell-wrapper): detection, alias parsing, marker-bounded rc surgery
 ```
 
 ## Adding a skill

--- a/hooks/repo/tests/run.sh
+++ b/hooks/repo/tests/run.sh
@@ -16,7 +16,7 @@
 # diverge from the breakdown (repo#44). Currently delegated:
 # test-guard-destructive.sh (the full guard regression suite),
 # test-session-start-handoff.sh, test-install-claude-md-markers.sh,
-# commands/repo/tests/test-branches-loss-check.sh, and
+# test-shell-wrapper.sh, commands/repo/tests/test-branches-loss-check.sh, and
 # commands/repo/tests/test-repo-remote.sh.
 #
 # `pnpm test` is this repo's only automated gate — there is no CI — so it must
@@ -325,6 +325,44 @@ else
     PASS=$((PASS + MD_PASS))
     FAIL=$((FAIL + MD_FAIL))
     record_suite "test-install-claude-md-markers.sh" "$MD_PASS" "$MD_FAIL" "CLAUDE.md markers"
+fi
+
+# install.sh --shell-wrapper / uninstall.sh's shell `claude` wrapper (repo#35).
+# Same delegation shape as the two suites above: drives the installers against
+# a scratch $HOME so real shell rc files are never touched. Fold its real
+# PASS/FAIL counts in and record a breakdown row, same discipline as every
+# other delegated suite here (repo#44).
+echo
+echo "-- shell claude wrapper (delegated suite) --"
+SW_TEST="$TESTS_DIR/test-shell-wrapper.sh"
+if [[ ! -f "$SW_TEST" ]]; then
+    FAIL=$((FAIL + 1))
+    record_suite "test-shell-wrapper.sh" 0 1 "not found"
+    printf '  FAIL %-52s -> not found at %s\n' "test-shell-wrapper.sh" "$SW_TEST"
+else
+    SW_OUT="$(bash "$SW_TEST" 2>&1)"
+    SW_STATUS=$?
+    SW_PASS="$(suite_count Passed "$SW_OUT")"
+    SW_FAIL="$(suite_count Failed "$SW_OUT")"
+    if ! [[ "$SW_PASS" =~ ^[0-9]+$ && "$SW_FAIL" =~ ^[0-9]+$ ]]; then
+        # Summary block missing or unparseable (e.g. the suite died early under
+        # its own `set -e`). Never let that fold in as zero failures.
+        SW_PASS=0
+        SW_FAIL=1
+        printf '  FAIL %-52s -> no parseable summary (exit %s); output tail follows\n' \
+            "test-shell-wrapper.sh" "$SW_STATUS"
+        strip_ansi "$SW_OUT" | tail -30 | sed 's/^/    /'
+    elif [[ "$SW_STATUS" -ne 0 || "$SW_FAIL" -ne 0 ]]; then
+        [[ "$SW_FAIL" -eq 0 ]] && SW_FAIL=1  # non-zero exit with no counted failure
+        printf '  FAIL %-52s -> %s pass, %s fail (exit %s); failures follow\n' \
+            "test-shell-wrapper.sh" "$SW_PASS" "$SW_FAIL" "$SW_STATUS"
+        strip_ansi "$SW_OUT" | grep -E '^ +FAIL' | sed 's/^/  /'
+    else
+        printf '  ok   %-52s -> %s cases pass\n' "test-shell-wrapper.sh" "$SW_PASS"
+    fi
+    PASS=$((PASS + SW_PASS))
+    FAIL=$((FAIL + SW_FAIL))
+    record_suite "test-shell-wrapper.sh" "$SW_PASS" "$SW_FAIL" "claude shell wrapper"
 fi
 
 # The command files under commands/repo/ are prose, not scripts, so they have no

--- a/hooks/repo/tests/test-shell-wrapper.sh
+++ b/hooks/repo/tests/test-shell-wrapper.sh
@@ -1,0 +1,461 @@
+#!/usr/bin/env bash
+# Test suite for lib/shell-wrapper.sh and its install.sh --shell-wrapper /
+# uninstall.sh wiring (repo#35).
+#
+# Usage: ./hooks/repo/tests/test-shell-wrapper.sh
+# Exit code 0 = all tests pass, 1 = failures detected.
+#
+# Structured like test-session-start-handoff.sh / test-install-claude-md-markers.sh
+# next door: pure bash, no test framework, PASS/FAIL counters and a summary
+# block. install.sh/uninstall.sh are driven with HOME pointed at a scratch
+# directory so real shell rc files are never touched.
+#
+# The contract under test:
+#   - --yes without --shell-wrapper is a strict no-op (rc never read/written)
+#   - --shell-wrapper folds an existing `alias claude=...`'s flags into the
+#     function, adds `unalias claude` ahead of the function definition, and
+#     never invokes `claude` recursively (always `command claude`)
+#   - the block is marker-bounded and idempotent (re-install replaces in place)
+#   - a backup exists after every edit
+#   - fish is skipped with a clear message, rc untouched
+#   - uninstall.sh removes the block (backed up) and is a no-op once absent
+#   - the rendered banner function itself behaves correctly at runtime (fresh
+#     note, stale note, no note, non-git cwd)
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+INSTALL_SH="$REPO_ROOT/install.sh"
+UNINSTALL_SH="$REPO_ROOT/uninstall.sh"
+LIB="$REPO_ROOT/lib/shell-wrapper.sh"
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+for f in "$INSTALL_SH" "$UNINSTALL_SH" "$LIB"; do
+    if [[ ! -f "$f" ]]; then
+        echo "FATAL: required file not found at $f" >&2
+        exit 1
+    fi
+done
+
+# Resolve to a PHYSICAL path (macOS mktemp -d hands back /var/folders/..., a
+# symlink to /private/var/folders/...) so md5/diff comparisons never trip on
+# the two spellings of the same path.
+SCRATCH="$(cd "$(mktemp -d)" && pwd -P)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+# ---------------------------------------------------------------------------
+# Assertion helpers
+# ---------------------------------------------------------------------------
+
+ok() {   # <label>
+    TOTAL=$((TOTAL + 1)); PASS=$((PASS + 1))
+    printf "  ${GREEN}PASS${NC}: %s\n" "$1"
+}
+no() {   # <label> <detail>
+    TOTAL=$((TOTAL + 1)); FAIL=$((FAIL + 1))
+    printf "  ${RED}FAIL${NC}: %s\n" "$1"
+    [[ -n "${2:-}" ]] && printf "%s\n" "$2" | sed 's/^/        /'
+    return 0
+}
+assert_eq() {  # <label> <expected> <actual>
+    if [[ "$2" == "$3" ]]; then ok "$1"; else no "$1" "expected [$2], got [$3]"; fi
+}
+assert_contains() {  # <label> <haystack> <needle>
+    if [[ "$2" == *"$3"* ]]; then ok "$1"; else no "$1" "missing [$3] in:
+$2"; fi
+}
+assert_not_contains() {  # <label> <haystack> <needle>
+    if [[ "$2" != *"$3"* ]]; then ok "$1"; else no "$1" "unexpectedly present: [$3]"; fi
+}
+assert_file_bytes_eq() {  # <label> <file-a> <file-b>
+    if diff -u "$2" "$3" >/dev/null 2>&1; then
+        ok "$1"
+    else
+        no "$1" "$(diff -u "$2" "$3" | head -20)"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+new_home_target() {  # <name> -> prints "home_dir target_dir" (space-separated)
+    local base="$SCRATCH/$1" home target
+    home="$base/home"; target="$base/target"
+    mkdir -p "$home" "$target"
+    git init -q "$target" 2>/dev/null
+    printf '%s %s' "$home" "$target"
+}
+
+# ===========================================================================
+echo "lib/shell-wrapper.sh + install.sh --shell-wrapper suite"
+echo "========================================================="
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "-- unit: shell_wrapper_detect_shell / shell_wrapper_rc_path --"
+(
+    source "$LIB"
+    OUT_ZSH="$(SHELL=/bin/zsh shell_wrapper_detect_shell)"
+    [[ "$OUT_ZSH" == "zsh" ]] && echo "PASS: zsh detected via \$SHELL" || echo "FAIL: zsh detected via \$SHELL -> got [$OUT_ZSH]"
+
+    OUT_BASH="$(SHELL=/bin/bash shell_wrapper_detect_shell)"
+    [[ "$OUT_BASH" == "bash" ]] && echo "PASS: bash detected via \$SHELL" || echo "FAIL: bash detected via \$SHELL -> got [$OUT_BASH]"
+
+    OUT_FISH="$(SHELL=/usr/local/bin/fish shell_wrapper_detect_shell)"; FISH_RC=$?
+    [[ "$OUT_FISH" == "fish" && "$FISH_RC" -eq 1 ]] && echo "PASS: fish detected, non-zero return" || echo "FAIL: fish detection -> [$OUT_FISH] rc=$FISH_RC"
+
+    RC_ZSH="$(HOME=/scratch-home shell_wrapper_rc_path zsh)"
+    [[ "$RC_ZSH" == "/scratch-home/.zshrc" ]] && echo "PASS: zsh rc path" || echo "FAIL: zsh rc path -> [$RC_ZSH]"
+
+    RC_BASH="$(HOME=/scratch-home shell_wrapper_rc_path bash)"
+    [[ "$RC_BASH" == "/scratch-home/.bashrc" ]] && echo "PASS: bash rc path" || echo "FAIL: bash rc path -> [$RC_BASH]"
+) > "$SCRATCH/unit1.out" 2>&1
+while IFS= read -r line; do
+    case "$line" in
+        PASS:*) ok "${line#PASS: }" ;;
+        FAIL:*) no "${line#FAIL: }" ;;
+    esac
+done < "$SCRATCH/unit1.out"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "-- unit: shell_wrapper_parse_alias_flags --"
+(
+    source "$LIB"
+    if shell_wrapper_parse_alias_flags "alias claude='command claude --dangerously-skip-permissions'" \
+        && [[ "$SHELL_WRAPPER_FLAGS" == "--dangerously-skip-permissions" ]]; then
+        echo "PASS: parses 'command claude <flags>' form"
+    else
+        echo "FAIL: parses 'command claude <flags>' form -> [$SHELL_WRAPPER_FLAGS]"
+    fi
+
+    if shell_wrapper_parse_alias_flags "alias claude='claude --foo --bar=baz'" \
+        && [[ "$SHELL_WRAPPER_FLAGS" == "--foo --bar=baz" ]]; then
+        echo "PASS: parses bare 'claude <flags>' form"
+    else
+        echo "FAIL: parses bare 'claude <flags>' form -> [$SHELL_WRAPPER_FLAGS]"
+    fi
+
+    if shell_wrapper_parse_alias_flags "alias claude='claude'" && [[ -z "$SHELL_WRAPPER_FLAGS" ]]; then
+        echo "PASS: parses no-flags alias as empty flags"
+    else
+        echo "FAIL: parses no-flags alias -> [$SHELL_WRAPPER_FLAGS]"
+    fi
+
+    if shell_wrapper_parse_alias_flags "alias claude='somethingelse --x'"; then
+        echo "FAIL: unrecognized alias target should be refused"
+    else
+        echo "PASS: unrecognized alias target refused"
+    fi
+) > "$SCRATCH/unit2.out" 2>&1
+while IFS= read -r line; do
+    case "$line" in
+        PASS:*) ok "${line#PASS: }" ;;
+        FAIL:*) no "${line#FAIL: }" ;;
+    esac
+done < "$SCRATCH/unit2.out"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "-- install.sh: --yes without --shell-wrapper is a strict no-op --"
+
+read -r H1 T1 <<<"$(new_home_target strict-noop)"
+cat > "$H1/.zshrc" <<'EOF'
+export FOO=bar
+EOF
+cp "$H1/.zshrc" "$SCRATCH/strict-noop-before.zshrc"
+
+OUT1="$(HOME="$H1" SHELL=/bin/zsh bash "$INSTALL_SH" -y "$T1" 2>&1)"; RC1=$?
+assert_eq "strict no-op: install exits 0" "0" "$RC1"
+assert_file_bytes_eq "strict no-op: .zshrc byte-identical" "$SCRATCH/strict-noop-before.zshrc" "$H1/.zshrc"
+assert_not_contains "strict no-op: no wrapper marker mentioned in output" "$OUT1" "REPO-SKILLS CLAUDE WRAPPER"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "-- install.sh --shell-wrapper: existing alias flags are preserved --"
+
+read -r H2 T2 <<<"$(new_home_target alias-preserve)"
+cat > "$H2/.zshrc" <<'EOF'
+# my zshrc
+export FOO=bar
+alias claude='command claude --dangerously-skip-permissions'
+EOF
+
+OUT2="$(HOME="$H2" SHELL=/bin/zsh bash "$INSTALL_SH" -y --shell-wrapper "$T2" 2>&1)"; RC2=$?
+BODY2="$(cat "$H2/.zshrc")"
+
+assert_eq "alias-preserve: install exits 0" "0" "$RC2"
+assert_contains "alias-preserve: reports success" "$OUT2" "Installed claude shell wrapper"
+assert_contains "alias-preserve: flag folded into command claude"  "$BODY2" "command claude --dangerously-skip-permissions \"\$@\""
+assert_contains "alias-preserve: unalias precedes the function"    "$BODY2" "unalias claude 2>/dev/null"
+assert_contains "alias-preserve: marker-bounded"                   "$BODY2" "# BEGIN REPO-SKILLS CLAUDE WRAPPER"
+assert_contains "alias-preserve: original alias line untouched"    "$BODY2" "alias claude='command claude --dangerously-skip-permissions'"
+assert_not_contains "alias-preserve: no bare recursive 'claude' call" "$BODY2" $'\n  claude "$@"'
+
+# unalias must appear textually BEFORE the function definition, or it cannot
+# neutralize an alias sourced earlier in the same rc.
+UNALIAS_POS="${BODY2%%unalias claude*}"
+FUNC_POS="${BODY2%%claude() {*}"
+assert_eq "alias-preserve: unalias precedes 'claude()' textually" "true" \
+    "$([[ ${#UNALIAS_POS} -lt ${#FUNC_POS} ]] && echo true || echo false)"
+
+# A backup must exist after the edit.
+BACKUP2="$(printf '%s\n' "$OUT2" | grep -o '/[^ ]*\.zshrc\.repo-skills-backup\.[A-Za-z0-9]*' | tail -1)"
+if [[ -n "$BACKUP2" && -f "$BACKUP2" ]]; then
+    ok "alias-preserve: backup file exists"
+    assert_contains "alias-preserve: backup holds the pre-edit content" "$(cat "$BACKUP2")" "alias claude='command claude --dangerously-skip-permissions'"
+else
+    no "alias-preserve: backup file exists" "no backup path found/created (parsed: [$BACKUP2])"
+fi
+
+# Idempotency: re-running with the same flag yields byte-identical content and
+# exactly one marker pair.
+BEFORE_RERUN="$(cat "$H2/.zshrc")"
+HOME="$H2" SHELL=/bin/zsh bash "$INSTALL_SH" -y --shell-wrapper "$T2" >/dev/null 2>&1
+AFTER_RERUN="$(cat "$H2/.zshrc")"
+assert_eq "alias-preserve: idempotent re-install (byte-identical)" "$BEFORE_RERUN" "$AFTER_RERUN"
+N_BEGIN="$(grep -cxF '# BEGIN REPO-SKILLS CLAUDE WRAPPER' "$H2/.zshrc")"
+assert_eq "alias-preserve: exactly one marker pair after re-install" "1" "$N_BEGIN"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "-- install.sh --shell-wrapper: no pre-existing alias --"
+
+read -r H3 T3 <<<"$(new_home_target no-alias)"
+cat > "$H3/.bashrc" <<'EOF'
+export FOO=bar
+EOF
+
+HOME="$H3" SHELL=/bin/bash bash "$INSTALL_SH" -y --shell-wrapper "$T3" >/dev/null 2>&1
+BODY3="$(cat "$H3/.bashrc")"
+assert_contains "no-alias: plain 'command claude' with no extra flags" "$BODY3" $'command claude "$@"'
+assert_not_contains "no-alias: no stray double space from empty flags" "$BODY3" "command claude  \"\$@\""
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "-- install.sh --shell-wrapper: rc file does not exist yet --"
+
+read -r H4 T4 <<<"$(new_home_target missing-rc)"
+# H4/.zshrc deliberately not created.
+HOME="$H4" SHELL=/bin/zsh bash "$INSTALL_SH" -y --shell-wrapper "$T4" >/dev/null 2>&1
+if [[ -f "$H4/.zshrc" ]]; then
+    ok "missing-rc: .zshrc created"
+    assert_contains "missing-rc: contains the wrapper block" "$(cat "$H4/.zshrc")" "# BEGIN REPO-SKILLS CLAUDE WRAPPER"
+else
+    no "missing-rc: .zshrc created" "file was not created"
+fi
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "-- install.sh --shell-wrapper: fish is skipped, rc untouched --"
+
+read -r H5 T5 <<<"$(new_home_target fish-skip)"
+OUT5="$(HOME="$H5" SHELL=/usr/local/bin/fish bash "$INSTALL_SH" -y --shell-wrapper "$T5" 2>&1)"; RC5=$?
+assert_eq "fish-skip: install still exits 0" "0" "$RC5"
+assert_contains "fish-skip: clear skip message" "$OUT5" "fish"
+if [[ -e "$H5/.zshrc" || -e "$H5/.bashrc" || -e "$H5/.config/fish" ]]; then
+    no "fish-skip: no rc file created for any shell" "found an rc under $H5"
+else
+    ok "fish-skip: no rc file created for any shell"
+fi
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "-- install.sh --shell-wrapper: unparseable existing alias bails cleanly --"
+
+read -r H6 T6 <<<"$(new_home_target alias-unparseable)"
+cat > "$H6/.zshrc" <<'EOF'
+# my zshrc
+alias claude='some-wrapper-script.sh --flag'
+EOF
+cp "$H6/.zshrc" "$SCRATCH/alias-unparseable-before.zshrc"
+
+OUT6="$(HOME="$H6" SHELL=/bin/zsh bash "$INSTALL_SH" -y --shell-wrapper "$T6" 2>&1)"; RC6=$?
+assert_eq "alias-unparseable: install still exits 0 (feature-local bail, not fatal)" "0" "$RC6"
+assert_contains "alias-unparseable: explains the bail" "$OUT6" "isn't in the supported single-line form"
+assert_file_bytes_eq "alias-unparseable: rc byte-identical (never guessed)" "$SCRATCH/alias-unparseable-before.zshrc" "$H6/.zshrc"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "-- install.sh --dry-run --shell-wrapper: enumerates without writing --"
+
+read -r H7 T7 <<<"$(new_home_target dry-run)"
+DRY7="$(HOME="$H7" SHELL=/bin/zsh bash "$INSTALL_SH" --dry-run --shell-wrapper "$T7" 2>&1)"
+assert_contains "dry-run: mentions the rc path" "$DRY7" "$H7/.zshrc"
+if [[ -f "$H7/.zshrc" ]]; then
+    no "dry-run: writes nothing" ".zshrc was created"
+else
+    ok "dry-run: writes nothing"
+fi
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "-- uninstall.sh: removes the block, backs it up, leaves the rest byte-identical --"
+
+read -r H8 T8 <<<"$(new_home_target uninstall-roundtrip)"
+cat > "$H8/.zshrc" <<'EOF'
+# my zshrc
+export FOO=bar
+EOF
+cp "$H8/.zshrc" "$SCRATCH/uninstall-roundtrip-expected.zshrc"
+
+HOME="$H8" SHELL=/bin/zsh bash "$INSTALL_SH" -y --shell-wrapper "$T8" >/dev/null 2>&1
+assert_contains "uninstall-roundtrip: wrapper present before uninstall" "$(cat "$H8/.zshrc")" "# BEGIN REPO-SKILLS CLAUDE WRAPPER"
+
+OUT8="$(HOME="$H8" SHELL=/bin/zsh bash "$UNINSTALL_SH" -y "$T8" 2>&1)"; RC8=$?
+assert_eq "uninstall-roundtrip: uninstall exits 0" "0" "$RC8"
+assert_contains "uninstall-roundtrip: reports removal" "$OUT8" "Removed claude shell wrapper from"
+assert_file_bytes_eq "uninstall-roundtrip: .zshrc back to original content" \
+    "$SCRATCH/uninstall-roundtrip-expected.zshrc" "$H8/.zshrc"
+
+# Second uninstall run: no-op (block already absent).
+BEFORE9="$(cat "$H8/.zshrc")"
+OUT9="$(HOME="$H8" SHELL=/bin/zsh bash "$UNINSTALL_SH" -y "$T8" 2>&1)"
+AFTER9="$(cat "$H8/.zshrc")"
+assert_eq "uninstall-roundtrip: second run leaves .zshrc unchanged" "$BEFORE9" "$AFTER9"
+assert_not_contains "uninstall-roundtrip: second run reports no removal" "$OUT9" "Removed claude shell wrapper from"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "-- guard: ambiguous marker layout is refused, never guessed --"
+
+read -r H10 T10 <<<"$(new_home_target ambiguous)"
+cat > "$H10/.zshrc" <<'EOF'
+# BEGIN REPO-SKILLS CLAUDE WRAPPER
+first (hand-duplicated)
+# END REPO-SKILLS CLAUDE WRAPPER
+# BEGIN REPO-SKILLS CLAUDE WRAPPER
+second (hand-duplicated)
+# END REPO-SKILLS CLAUDE WRAPPER
+EOF
+cp "$H10/.zshrc" "$SCRATCH/ambiguous-before.zshrc"
+
+OUT10="$(HOME="$H10" SHELL=/bin/zsh bash "$INSTALL_SH" -y --shell-wrapper "$T10" 2>&1)"
+assert_contains "ambiguous: reports refusal" "$OUT10" "ambiguous REPO-SKILLS CLAUDE WRAPPER marker layout"
+assert_file_bytes_eq "ambiguous: rc untouched" "$SCRATCH/ambiguous-before.zshrc" "$H10/.zshrc"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "-- runtime: the rendered banner function behaves correctly --"
+
+# Extract just the body between the markers and source it into a throwaway
+# bash, then exercise _repo_claude_handoff_banner directly — this is the part
+# that actually runs every time a user launches `claude`, so it is verified
+# for real rather than just asserting the text is present.
+render_body() {  # <flags> -> the block's body (markers stripped), to stdout
+    (
+        source "$LIB"
+        shell_wrapper_render_block "$1"
+    ) | sed '1d;$d'
+}
+
+RT_HOME="$SCRATCH/runtime-repo"
+mkdir -p "$RT_HOME"
+git init -q "$RT_HOME" 2>/dev/null
+
+BLOCK_FILE="$SCRATCH/runtime-block.sh"
+render_body "" > "$BLOCK_FILE"
+
+# No note present -> silent, no output.
+OUT_NONOTE="$(cd "$RT_HOME" && bash -c "source '$BLOCK_FILE'; _repo_claude_handoff_banner" 2>&1)"
+assert_eq "runtime: no note -> silent" "" "$OUT_NONOTE"
+
+# Fresh note -> banner with path + "just now", no STALE warning.
+mkdir -p "$RT_HOME/.claude"
+cat > "$RT_HOME/.claude/handoff.md" <<'EOF'
+# Handoff — today
+
+## In-flight
+Resolve this first.
+
+## Decisions
+Settled.
+EOF
+OUT_FRESH="$(cd "$RT_HOME" && bash -c "source '$BLOCK_FILE'; _repo_claude_handoff_banner" 2>&1)"
+assert_contains "runtime: fresh note -> banner header" "$OUT_FRESH" "Handoff note pending"
+assert_contains "runtime: fresh note -> path shown" "$OUT_FRESH" "$RT_HOME/.claude/handoff.md"
+assert_contains "runtime: fresh note -> age just now" "$OUT_FRESH" "just now"
+assert_contains "runtime: fresh note -> section outline" "$OUT_FRESH" "In-flight"
+assert_not_contains "runtime: fresh note -> no STALE warning" "$OUT_FRESH" "STALE"
+
+# Stale note (mtime forced 8 days back) -> STALE warning present.
+OLD_EPOCH=$(( $(date +%s) - 8*24*3600 ))
+if touch -d "@$OLD_EPOCH" "$RT_HOME/.claude/handoff.md" 2>/dev/null \
+    || touch -t "$(date -r "$OLD_EPOCH" +%Y%m%d%H%M.%S 2>/dev/null)" "$RT_HOME/.claude/handoff.md" 2>/dev/null; then
+    OUT_STALE="$(cd "$RT_HOME" && bash -c "source '$BLOCK_FILE'; _repo_claude_handoff_banner" 2>&1)"
+    assert_contains "runtime: stale note -> STALE warning" "$OUT_STALE" "STALE"
+else
+    no "runtime: stale note -> STALE warning" "could not backdate mtime with either GNU or BSD touch"
+fi
+rm -f "$RT_HOME/.claude/handoff.md"
+
+# Non-git cwd -> falls back to $PWD, never errors.
+NONGIT="$SCRATCH/nongit-dir"
+mkdir -p "$NONGIT"
+OUT_NONGIT="$(cd "$NONGIT" && bash -c "source '$BLOCK_FILE'; _repo_claude_handoff_banner" 2>&1)"
+assert_eq "runtime: non-git cwd -> silent, no error" "" "$OUT_NONGIT"
+
+# _repo_claude_is_session gating — matches the minimum list from repo#32/#35.
+GATE_OUT="$(bash -c "source '$BLOCK_FILE'
+for s in update doctor mcp config install migrate-installer setup-token -v --version -h --help; do
+  if _repo_claude_is_session \"\$s\"; then echo \"FAIL:\$s\"; fi
+done
+for s in '' chat 'some-prompt'; do
+  if ! _repo_claude_is_session \"\$s\"; then echo \"FAIL:default:\$s\"; fi
+done
+echo DONE" 2>&1)"
+if [[ "$GATE_OUT" == *DONE ]] && [[ "$GATE_OUT" != *FAIL* ]]; then
+    ok "runtime: _repo_claude_is_session gates the documented subcommand list"
+else
+    no "runtime: _repo_claude_is_session gates the documented subcommand list" "$GATE_OUT"
+fi
+
+# The claude() function itself: never recurses (never calls bare "claude"),
+# and always falls through to `command claude "$@"` even when its own helpers
+# are undefined (repo#35 field-report fail-transparent requirement).
+RECURSE_CHECK="$(bash -c "
+claude() { echo SHOULD_NOT_RUN; }  # simulate a shadow the wrapper must not hit
+$(cat "$BLOCK_FILE")
+command() { if [[ \"\$1\" == claude ]]; then shift; echo \"command-claude-called:\$*\"; else builtin command \"\$@\"; fi; }
+claude --version
+" 2>&1)"
+assert_eq "runtime: claude() invokes 'command claude', passing argv through" \
+    "command-claude-called:--version" "$RECURSE_CHECK"
+
+# Helpers deliberately undefined -> claude() still falls through transparently.
+NOHELPERS="$(bash -c "
+claude() {
+  if type _repo_claude_is_session >/dev/null 2>&1 && type _repo_claude_handoff_banner >/dev/null 2>&1; then
+    _repo_claude_is_session \"\${1:-}\" && _repo_claude_handoff_banner
+  fi
+  command claude \"\$@\"
+}
+command() { if [[ \"\$1\" == claude ]]; then shift; echo \"passthrough:\$*\"; else builtin command \"\$@\"; fi; }
+claude mcp list
+" 2>&1)"
+assert_eq "runtime: missing helpers -> transparent passthrough, argv unchanged" \
+    "passthrough:mcp list" "$NOHELPERS"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "========================================="
+echo "  Total:  $TOTAL"
+printf "  ${GREEN}Passed${NC}: %s\n" "$PASS"
+printf "  ${RED}Failed${NC}: %s\n" "$FAIL"
+echo "========================================="
+
+if [[ $FAIL -gt 0 ]]; then
+    printf "\n${RED}TESTS FAILED${NC}\n"
+    exit 1
+fi
+printf "\n${GREEN}ALL TESTS PASSED${NC}\n"
+exit 0

--- a/install.sh
+++ b/install.sh
@@ -4,19 +4,27 @@
 # Usage: ./install.sh [OPTIONS] [/path/to/target-repo]
 #
 # Options:
-#   --skills=a,b,c   Install only these commands (default: all)
-#   --dev            Symlink source files instead of copying (for dogfooding);
-#                    allows installing into the source repo itself
-#   --list           List available commands and exit
-#   --dry-run        Show what would be written without writing
-#   -y, --yes        Non-interactive mode (skip confirmation prompts)
-#   -h, --help       Show this help
+#   --skills=a,b,c    Install only these commands (default: all)
+#   --dev             Symlink source files instead of copying (for dogfooding);
+#                     allows installing into the source repo itself
+#   --list            List available commands and exit
+#   --dry-run         Show what would be written without writing
+#   -y, --yes         Non-interactive mode (skip confirmation prompts)
+#   --shell-wrapper   Opt into a shell `claude` wrapper (edits ~/.zshrc or
+#                     ~/.bashrc — the only thing this installer writes outside
+#                     the target repo) that surfaces a pending /repo:handoff
+#                     note before Claude starts. Default: off. Even without
+#                     this flag, an interactive install still offers it via a
+#                     confirm (default N, diff shown first); under --yes it is
+#                     always a strict no-op unless this flag is also passed.
+#   -h, --help        Show this help
 #
 # Examples:
 #   ./install.sh ~/projects/my-app
 #   ./install.sh --skills=clean,remote .
 #   ./install.sh --dry-run ~/projects/my-app
 #   ./install.sh --dev .            # dogfood: live /repo:* here via symlinks
+#   ./install.sh -y --shell-wrapper ~/projects/my-app   # opt into the shell wrapper non-interactively
 
 set -euo pipefail
 
@@ -58,6 +66,12 @@ MARKER_END='<!-- END REPO-SKILLS -->'
 # rewrite the block by hand here — see lib/claude-md-block.sh (repo#38).
 # shellcheck source=lib/claude-md-block.sh
 source "$SOURCE_ROOT/lib/claude-md-block.sh"
+
+# Shell `claude` wrapper (opt-in via --shell-wrapper) — the one thing this
+# installer can write outside the target repo. See lib/shell-wrapper.sh
+# (repo#35) for the detection/parsing/rewrite logic and its safety contract.
+# shellcheck source=lib/shell-wrapper.sh
+source "$SOURCE_ROOT/lib/shell-wrapper.sh"
 
 claude_md_has_block() { [[ -f "$TARGET/CLAUDE.md" ]] && grep -qF "$MARKER_BEGIN" "$TARGET/CLAUDE.md"; }
 
@@ -123,8 +137,9 @@ SKILLS_FILTER=""
 DRY_RUN=false
 YES=false
 DEV=false
+SHELL_WRAPPER=false
 
-usage() { sed -n '2,16p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; }
+usage() { sed -n '2,27p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; }
 
 list_commands() {
   for f in "$SOURCE_ROOT"/commands/repo/*.md; do
@@ -134,12 +149,13 @@ list_commands() {
 
 for arg in "$@"; do
   case "$arg" in
-    --skills=*) SKILLS_FILTER="${arg#--skills=}" ;;
-    --dev)      DEV=true ;;
-    --list)     list_commands; exit 0 ;;
-    --dry-run)  DRY_RUN=true ;;
-    -y|--yes)   YES=true ;;
-    -h|--help)  usage; exit 0 ;;
+    --skills=*)      SKILLS_FILTER="${arg#--skills=}" ;;
+    --dev)           DEV=true ;;
+    --list)          list_commands; exit 0 ;;
+    --dry-run)       DRY_RUN=true ;;
+    -y|--yes)        YES=true ;;
+    --shell-wrapper) SHELL_WRAPPER=true ;;
+    -h|--help)       usage; exit 0 ;;
     -*)         error "Unknown option: $arg (see --help)" ;;
     *)          [[ -n "$TARGET" ]] && error "Multiple targets given: $TARGET and $arg"
                 TARGET="$arg" ;;
@@ -243,6 +259,16 @@ if [[ "$DRY_RUN" == true ]]; then
   else
     echo "  $TARGET/.gitignore (.claude/skills/repo/.install-local.json entry)"
     echo "  $TARGET/CLAUDE.md (marker-bounded REPO-SKILLS block)"
+  fi
+  if [[ "$SHELL_WRAPPER" == true ]]; then
+    _dry_run_sw_shell="$(shell_wrapper_detect_shell)" || _dry_run_sw_shell="unsupported"
+    if [[ "$_dry_run_sw_shell" == zsh || "$_dry_run_sw_shell" == bash ]]; then
+      echo "  $(shell_wrapper_rc_path "$_dry_run_sw_shell") (outside $TARGET — marker-bounded claude shell wrapper; --shell-wrapper)"
+    else
+      echo "  (--shell-wrapper given, but no supported shell detected — would skip: $_dry_run_sw_shell)"
+    fi
+  else
+    echo "  (pass --shell-wrapper to also preview the optional claude shell wrapper, outside $TARGET)"
   fi
   exit 0
 fi
@@ -471,6 +497,62 @@ install_file "$SOURCE_ROOT/scripts/repo/repo-remote.sh" \
   "$TARGET/.claude/skills/repo/scripts/repo-remote.sh" "scripts/repo/repo-remote.sh"
 chmod +x "$TARGET/.claude/skills/repo/scripts/repo-remote.sh" 2>/dev/null || true
 success "Installed .claude/skills/repo/scripts/repo-remote.sh"
+
+# 3e. Optional shell `claude` wrapper — surfaces a pending /repo:handoff note
+# to the HUMAN before Claude starts (the SessionStart hook above is the half
+# Claude itself sees). This is the one thing install.sh writes outside the
+# target repo, so unlike every step above it is opt-in and defensive: a
+# strict no-op under --yes without --shell-wrapper, the pending diff is always
+# shown before anything is written, an interactive install without the flag
+# still offers it via confirm (default N), and the rc file is backed up before
+# every edit. Runs unconditionally (before the dev-mode / gitignored-target
+# early exits below) since it is independent of $TARGET entirely.
+if [[ "$YES" == true && "$SHELL_WRAPPER" != true ]]; then
+  : # strict no-op — the rc file is neither read nor written
+else
+  SW_SHELL="$(shell_wrapper_detect_shell)" || true
+  if [[ -z "$SW_SHELL" || "$SW_SHELL" == "unknown" ]]; then
+    warning "claude shell wrapper: could not detect a supported shell (checked \$SHELL, \$ZSH_VERSION, \$BASH_VERSION) — skipping"
+  elif [[ "$SW_SHELL" == "fish" ]]; then
+    warning "claude shell wrapper: detected fish, which isn't supported yet (zsh/bash only) — skipping rather than half-supporting it"
+  else
+    SW_RC="$(shell_wrapper_rc_path "$SW_SHELL")"
+    if ! shell_wrapper_plan "$SW_RC"; then
+      warning "claude shell wrapper: $SHELL_WRAPPER_ERROR"
+    else
+      SW_PREVIEW_BEFORE="$(mktemp)"
+      [[ -f "$SW_RC" ]] && cp "$SW_RC" "$SW_PREVIEW_BEFORE" || : >"$SW_PREVIEW_BEFORE"
+      SW_PREVIEW_AFTER="$(mktemp)"
+      cp "$SW_PREVIEW_BEFORE" "$SW_PREVIEW_AFTER"
+      if ! shell_wrapper_install "$SW_PREVIEW_AFTER" "$SHELL_WRAPPER_FLAGS"; then
+        warning "claude shell wrapper: could not prepare a preview: $SHELL_WRAPPER_ERROR"
+        rm -f "$SW_PREVIEW_BEFORE" "$SW_PREVIEW_AFTER"
+      else
+        echo ""
+        info "claude shell wrapper ($SW_SHELL) would change $SW_RC:"
+        diff -u "$SW_PREVIEW_BEFORE" "$SW_PREVIEW_AFTER" | tail -n +3 || true
+        rm -f "$SW_PREVIEW_BEFORE" "$SW_PREVIEW_AFTER" "$SHELL_WRAPPER_BACKUP"
+
+        SW_PROCEED=false
+        if [[ "$SHELL_WRAPPER" == true ]]; then
+          SW_PROCEED=true
+        elif confirm "Install the claude shell wrapper into $SW_RC? [y/N] " N; then
+          SW_PROCEED=true
+        fi
+
+        if [[ "$SW_PROCEED" == true ]]; then
+          if shell_wrapper_install "$SW_RC" "$SHELL_WRAPPER_FLAGS"; then
+            success "Installed claude shell wrapper into $SW_RC (backed up to $SHELL_WRAPPER_BACKUP)"
+          else
+            warning "claude shell wrapper: could not install it: $SHELL_WRAPPER_ERROR"
+          fi
+        else
+          info "Skipped the claude shell wrapper"
+        fi
+      fi
+    fi
+  fi
+fi
 
 # 4. CLAUDE.md block (replace existing block in place, else append).
 # Skipped in dev mode: the symlinked install is machine-local (absolute symlinks

--- a/lib/shell-wrapper.sh
+++ b/lib/shell-wrapper.sh
@@ -1,0 +1,372 @@
+#!/usr/bin/env bash
+# lib/shell-wrapper.sh — the shell `claude` wrapper install.sh can opt into with
+# --shell-wrapper. This file is *sourced* (by install.sh and uninstall.sh),
+# never executed directly.
+#
+# WHAT THIS SHIPS: a marker-bounded block appended to the user's shell rc
+# (~/.zshrc or ~/.bashrc) that defines a `claude` function. Before a
+# session-starting invocation, the function prints a banner if
+# `.claude/handoff.md` exists in the current repo — the same note
+# hooks/repo/session-start-handoff.sh (repo#34) injects into Claude's own
+# context. That hook covers "Claude sees the note"; this wrapper covers "the
+# human sees it before launch". See repo#32 (design) and repo#35 (this file).
+#
+# WHY THIS IS THE ONE RISKY PIECE OF THE INSTALLER: every other file
+# install.sh writes lives inside the target repo. A shell rc is global — it
+# affects every repo and every shell the user opens. Hard requirements that
+# follow from that (see install.sh's --shell-wrapper wiring, not enforced by
+# this file alone):
+#   - opt-in, default N, diff shown before writing
+#   - strict no-op under --yes unless --shell-wrapper is explicit
+#   - rc file backed up before every edit
+#   - marker-bounded, idempotent (re-running replaces the block in place)
+#
+# CONTRACT (functions below, all safe to call with `set -euo pipefail` active
+# in the caller — none of these ever let an internal "not found" case escape
+# as an uncaught non-zero under `set -e`):
+#
+#   shell_wrapper_detect_shell()
+#       Echoes "zsh" | "bash" | "fish" | "unknown". Return status 0 for
+#       zsh/bash, 1 for fish/unknown (caller decides how to report each).
+#
+#   shell_wrapper_rc_path <shell>
+#       Echoes the rc file path for "zsh"/"bash". Return 1 (no output) for
+#       anything else.
+#
+#   shell_wrapper_plan <rcfile>
+#       Detects a pre-existing single-line `alias claude=...` in <rcfile> (if
+#       any) and parses its flags into SHELL_WRAPPER_FLAGS (may be empty).
+#       Never touches <rcfile>. Returns 0 (possibly with empty
+#       SHELL_WRAPPER_FLAGS) when it is safe to proceed, or 1 with
+#       SHELL_WRAPPER_ERROR set when an existing alias could not be parsed
+#       (the common single-line `alias claude='[command] claude ...'` form is
+#       supported; anything else is a deliberate bail, not a guess — see
+#       repo#35's scope guard).
+#
+#   shell_wrapper_install <rcfile> <flags>
+#       Backs up <rcfile> (path left in SHELL_WRAPPER_BACKUP), then writes the
+#       marker-bounded wrapper block — replacing an existing block in place,
+#       or appending if none exists — folding <flags> into the function's
+#       `command claude` invocation. Creates <rcfile> if it does not exist.
+#       Returns 1 with SHELL_WRAPPER_ERROR set (rcfile left untouched) if the
+#       marker layout in <rcfile> is ambiguous (more than one BEGIN/END).
+#
+#   shell_wrapper_uninstall <rcfile>
+#       Removes the marker-bounded block from <rcfile> if present (backing it
+#       up first, path in SHELL_WRAPPER_BACKUP). No-op, return 0, if the block
+#       is absent or <rcfile> does not exist. Same ambiguous-layout guard as
+#       install.
+#
+#   shell_wrapper_block_present <rcfile>
+#       Return 0 if <rcfile> contains our BEGIN marker, 1 otherwise (or if
+#       <rcfile> does not exist).
+
+SHELL_WRAPPER_MARKER_BEGIN='# BEGIN REPO-SKILLS CLAUDE WRAPPER'
+SHELL_WRAPPER_MARKER_END='# END REPO-SKILLS CLAUDE WRAPPER'
+
+# Public output channels — set by the functions above, read by callers after a
+# non-zero return (or after a successful install/uninstall, for the backup
+# path). shellcheck: this file is only ever sourced, so "unused" is expected.
+# shellcheck disable=SC2034
+SHELL_WRAPPER_ERROR=""
+SHELL_WRAPPER_BACKUP=""
+SHELL_WRAPPER_FLAGS=""
+
+shell_wrapper_detect_shell() {
+  local sh_name=""
+  if [[ -n "${SHELL:-}" ]]; then
+    sh_name="$(basename "$SHELL" 2>/dev/null || true)"
+  fi
+  case "$sh_name" in
+    zsh)  echo zsh;  return 0 ;;
+    bash) echo bash; return 0 ;;
+    fish) echo fish; return 1 ;;
+  esac
+  # $SHELL absent/unrecognized (e.g. not set, or a non-standard login shell
+  # path) — fall back to which interpreter is actually running us.
+  if [[ -n "${ZSH_VERSION:-}" ]]; then
+    echo zsh; return 0
+  fi
+  if [[ -n "${BASH_VERSION:-}" ]]; then
+    echo bash; return 0
+  fi
+  echo unknown
+  return 1
+}
+
+shell_wrapper_rc_path() {  # <shell>
+  case "$1" in
+    zsh)  echo "${ZDOTDIR:-$HOME}/.zshrc" ;;
+    bash) echo "$HOME/.bashrc" ;;
+    *)    return 1 ;;
+  esac
+}
+
+shell_wrapper_block_present() {  # <rcfile>
+  [[ -f "$1" ]] && grep -qF "$SHELL_WRAPPER_MARKER_BEGIN" "$1" 2>/dev/null
+}
+
+# Last non-comment `alias claude=...` line in <rcfile> (empty if none). "Last"
+# because that is what the shell itself would honor if the file were sourced
+# top to bottom; "non-comment" so a stale, disabled alias someone left as a
+# `# alias claude=...` note is not mistaken for a live one.
+_shell_wrapper_find_alias_line() {  # <rcfile>
+  local rcfile="$1"
+  [[ -f "$rcfile" ]] || return 0
+  awk '
+    /^[[:space:]]*#/ { next }
+    /^[[:space:]]*alias[[:space:]]+claude=/ { line = $0 }
+    END { if (line != "") print line }
+  ' "$rcfile" 2>/dev/null || true
+}
+
+# Parse the common single-line form: alias claude='[command] claude <flags>'
+# (or double-quoted). Anything else — multi-line, unquoted, aliasing to a
+# different binary entirely — is refused rather than guessed (repo#35 scope
+# guard: support the common form, bail out clearly otherwise).
+shell_wrapper_parse_alias_flags() {  # <alias-line>
+  local line="$1" body=""
+  SHELL_WRAPPER_FLAGS=""
+  if [[ "$line" =~ alias[[:space:]]+claude=\'([^\']*)\'[[:space:]]*$ ]]; then
+    body="${BASH_REMATCH[1]}"
+  elif [[ "$line" =~ alias[[:space:]]+claude=\"([^\"]*)\"[[:space:]]*$ ]]; then
+    body="${BASH_REMATCH[1]}"
+  else
+    return 1
+  fi
+  if [[ "$body" =~ ^command[[:space:]]+claude([[:space:]].*)?$ ]]; then
+    SHELL_WRAPPER_FLAGS="$(echo "${BASH_REMATCH[1]:-}" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+  elif [[ "$body" =~ ^claude([[:space:]].*)?$ ]]; then
+    SHELL_WRAPPER_FLAGS="$(echo "${BASH_REMATCH[1]:-}" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+  else
+    return 1
+  fi
+  return 0
+}
+
+# Detect + parse an existing alias in <rcfile> (never writes anything).
+# Returns 0 with SHELL_WRAPPER_FLAGS set (possibly empty — no alias found is
+# not an error) or 1 with SHELL_WRAPPER_ERROR set (an alias exists but could
+# not be safely parsed).
+shell_wrapper_plan() {  # <rcfile>
+  local rcfile="$1" alias_line
+  # shellcheck disable=SC2034 # public output var, read by callers after return
+  SHELL_WRAPPER_FLAGS=""
+  SHELL_WRAPPER_ERROR=""
+  alias_line="$(_shell_wrapper_find_alias_line "$rcfile")"
+  [[ -n "$alias_line" ]] || return 0
+  if shell_wrapper_parse_alias_flags "$alias_line"; then
+    return 0
+  fi
+  SHELL_WRAPPER_ERROR="Found an existing claude alias in $rcfile that isn't in the supported single-line form (alias claude='[command] claude <flags>'): ${alias_line}. Simplify or remove it by hand, then re-run with --shell-wrapper."
+  return 1
+}
+
+# The wrapper function body, zsh+bash compatible. {{CLAUDE_INVOCATION}} is
+# substituted by shell_wrapper_render_block below via literal (non-regex)
+# parameter substitution — never via sed, so flags containing sed-special
+# characters can't corrupt the template.
+#
+# Design notes (repo#35 field report on a divergent, non-reference wrapper
+# breaking non-interactive `claude mcp list`): every helper this function
+# calls is defined in THIS SAME BLOCK, so a shell that sources the rc gets all
+# of it or none of it — never a function without its helpers. The `type`
+# guard before calling the banner helper means a helper somehow missing (e.g.
+# a user's own partial edit inside the markers) skips the banner rather than
+# erroring, and `command claude {{CLAUDE_INVOCATION}} "$@"` runs unconditionally
+# either way — argv passed to the real `claude` binary is never altered by
+# whether the banner fired.
+read -r -d '' _SHELL_WRAPPER_BODY_TEMPLATE <<'REPOSKILLSBLOCK' || true
+# Installed by Repo Skills (https://github.com/rjwalters/repo) install.sh
+# --shell-wrapper. Surfaces a pending /repo:handoff note before Claude starts
+# — the human-visible half of the handoff workflow (the SessionStart hook
+# covers the half Claude itself sees). Edit outside these markers only;
+# re-running install.sh --shell-wrapper replaces this block in place. To
+# remove: ./uninstall.sh (from the repo-skills source, or a target repo with
+# repo-skills installed) — it detects and removes this block automatically.
+unalias claude 2>/dev/null
+
+_repo_claude_is_session() {
+  case "$1" in
+    update|doctor|mcp|config|install|migrate-installer|setup-token) return 1 ;;
+    -v|--version|-h|--help) return 1 ;;
+    *) return 0 ;;
+  esac
+}
+
+_repo_claude_handoff_banner() {
+  local root note
+  root="$(command git rev-parse --show-toplevel 2>/dev/null)" || root="$PWD"
+  note="$root/.claude/handoff.md"
+  [ -r "$note" ] || return 0
+
+  local now mtime age_h age_label
+  now=$(command date +%s 2>/dev/null) || return 0
+  mtime=$(command stat -f %m "$note" 2>/dev/null) || mtime=$(command stat -c %Y "$note" 2>/dev/null) || return 0
+  case "$mtime" in
+    ''|*[!0-9]*) return 0 ;;
+  esac
+  age_h=$(( (now - mtime) / 3600 ))
+  if   [ "$age_h" -lt 1 ];  then age_label="just now"
+  elif [ "$age_h" -lt 48 ]; then age_label="${age_h}h old"
+  else                           age_label="$(( age_h / 24 ))d old"
+  fi
+
+  local y=$'\033[33m' d=$'\033[2m' r=$'\033[0m' b=$'\033[1m'
+  printf '%s┌─ %sHandoff note pending%s%s — %s (%s)%s\n' \
+    "$y" "$b" "$r" "$y" "${note/#$HOME/~}" "$age_label" "$r"
+
+  command grep -E '^#{1,2} ' "$note" 2>/dev/null | command head -n 9 | command sed 's/^#* *//' | while IFS= read -r line; do
+    printf '%s│%s  %s\n' "$y" "$r" "$line"
+  done
+
+  if [ "$age_h" -ge 168 ]; then
+    printf '%s└─ %sSTALE (>7d) — a handoff describes one moment; verify before trusting.%s\n' "$y" "$b" "$r"
+  else
+    printf '%s└─%s %sClaude reads it via MEMORY.md; delete note + pointer once absorbed.%s\n' "$y" "$r" "$d" "$r"
+  fi
+}
+
+claude() {
+  if type _repo_claude_is_session >/dev/null 2>&1 && type _repo_claude_handoff_banner >/dev/null 2>&1; then
+    _repo_claude_is_session "${1:-}" && _repo_claude_handoff_banner
+  fi
+  command claude{{CLAUDE_INVOCATION}} "$@"
+}
+REPOSKILLSBLOCK
+
+shell_wrapper_render_block() {  # <flags> -> prints the marker-bounded block to stdout
+  local flags="$1" invocation="" body="$_SHELL_WRAPPER_BODY_TEMPLATE"
+  # Leading space only when there are flags to add, so the no-flags case
+  # renders as `command claude "$@"` — never a stray double space.
+  [[ -n "$flags" ]] && invocation=" $flags"
+  body="${body//\{\{CLAUDE_INVOCATION\}\}/$invocation}"
+  printf '%s\n' "$SHELL_WRAPPER_MARKER_BEGIN"
+  printf '%s\n' "$body"
+  printf '%s\n' "$SHELL_WRAPPER_MARKER_END"
+}
+
+# Replace the marker-bounded span in <rcfile> with <blockfile>'s contents,
+# writing the result to stdout. Only called once shell_wrapper_install has
+# already confirmed exactly one BEGIN and one END line exist.
+_shell_wrapper_replace_block() {  # <rcfile> <blockfile>
+  awk -v begin="$SHELL_WRAPPER_MARKER_BEGIN" -v end="$SHELL_WRAPPER_MARKER_END" -v blockfile="$2" '
+    $0 == begin {
+      while ((getline line < blockfile) > 0) print line
+      close(blockfile)
+      skip = 1
+      next
+    }
+    $0 == end { skip = 0; next }
+    !skip { print }
+  ' "$1"
+}
+
+# Append <blockfile> after <rcfile>'s existing content. Deliberately does NOT
+# insert a separating blank line — only the minimum newline needed so our
+# BEGIN marker starts its own line (never glued onto the tail of the user's
+# last line, the same adjacency hazard lib/claude-md-block.sh guards against).
+# That keeps append and _shell_wrapper_replace_block's removal path exactly
+# symmetric: uninstalling restores the original content byte-for-byte, with
+# no leftover blank line to account for.
+_shell_wrapper_append_block() {  # <rcfile> <blockfile>
+  cat "$1"
+  # `$(tail -c1 f)` is empty both when f is empty and when f already ends in a
+  # newline (command substitution strips trailing newlines) — either way,
+  # nothing more is needed before the block starts its own line.
+  [[ -n "$(tail -c1 "$1" 2>/dev/null)" ]] && echo ""
+  cat "$2"
+}
+
+# mktemp a backup of <rcfile> under the sentinel-and-count discipline shared
+# with lib/claude-md-block.sh: refuse to proceed rather than edit without one.
+_shell_wrapper_backup() {  # <rcfile>
+  local rcfile="$1" backup
+  backup="$(mktemp "${TMPDIR:-/tmp}/$(basename "$rcfile").repo-skills-backup.XXXXXX" 2>/dev/null)" || return 1
+  cp "$rcfile" "$backup" 2>/dev/null || { rm -f "$backup"; return 1; }
+  printf '%s' "$backup"
+}
+
+shell_wrapper_install() {  # <rcfile> <flags>
+  local rcfile="$1" flags="$2" n_begin n_end blockfile tmp backup
+  SHELL_WRAPPER_ERROR=""
+  SHELL_WRAPPER_BACKUP=""
+
+  [[ -f "$rcfile" ]] || : >"$rcfile" 2>/dev/null || {
+    SHELL_WRAPPER_ERROR="could not create $rcfile"
+    return 1
+  }
+
+  # grep -c prints the count even when it exits 1 (no match), so `|| echo 0`
+  # here would duplicate the "0" already on stdout; `|| true` just neutralizes
+  # the exit status for `set -e` without adding a second line, and the
+  # parameter-expansion default covers the (should-never-happen) empty case.
+  n_begin=$(grep -cxF "$SHELL_WRAPPER_MARKER_BEGIN" "$rcfile" 2>/dev/null || true); n_begin=${n_begin:-0}
+  n_end=$(grep -cxF "$SHELL_WRAPPER_MARKER_END" "$rcfile" 2>/dev/null || true); n_end=${n_end:-0}
+  if [[ "$n_begin" -gt 1 || "$n_end" -gt 1 || "$n_begin" -ne "$n_end" ]]; then
+    SHELL_WRAPPER_ERROR="ambiguous REPO-SKILLS CLAUDE WRAPPER marker layout in $rcfile ($n_begin begin / $n_end end) — refusing to touch it; remove the stale block by hand, then re-run"
+    return 1
+  fi
+
+  backup="$(_shell_wrapper_backup "$rcfile")" || {
+    SHELL_WRAPPER_ERROR="could not back up $rcfile before editing it"
+    return 1
+  }
+  SHELL_WRAPPER_BACKUP="$backup"
+
+  blockfile="$(mktemp)" || { SHELL_WRAPPER_ERROR="could not create a temp file"; return 1; }
+  shell_wrapper_render_block "$flags" >"$blockfile"
+
+  tmp="$(mktemp)" || { rm -f "$blockfile"; SHELL_WRAPPER_ERROR="could not create a temp file"; return 1; }
+  if [[ "$n_begin" -eq 1 ]]; then
+    _shell_wrapper_replace_block "$rcfile" "$blockfile" >"$tmp"
+  else
+    _shell_wrapper_append_block "$rcfile" "$blockfile" >"$tmp"
+  fi
+  rm -f "$blockfile"
+
+  if ! mv "$tmp" "$rcfile"; then
+    rm -f "$tmp"
+    SHELL_WRAPPER_ERROR="could not move the rewritten file into place (backup: $backup)"
+    return 1
+  fi
+  return 0
+}
+
+shell_wrapper_uninstall() {  # <rcfile>
+  local rcfile="$1" n_begin n_end backup tmp
+  SHELL_WRAPPER_ERROR=""
+  SHELL_WRAPPER_BACKUP=""
+  [[ -f "$rcfile" ]] || return 0
+
+  n_begin=$(grep -cxF "$SHELL_WRAPPER_MARKER_BEGIN" "$rcfile" 2>/dev/null || true); n_begin=${n_begin:-0}
+  n_end=$(grep -cxF "$SHELL_WRAPPER_MARKER_END" "$rcfile" 2>/dev/null || true); n_end=${n_end:-0}
+  [[ "$n_begin" -eq 0 && "$n_end" -eq 0 ]] && return 0
+
+  if [[ "$n_begin" -ne 1 || "$n_end" -ne 1 ]]; then
+    SHELL_WRAPPER_ERROR="ambiguous REPO-SKILLS CLAUDE WRAPPER marker layout in $rcfile ($n_begin begin / $n_end end) — leaving it untouched; remove the block by hand"
+    return 1
+  fi
+
+  backup="$(_shell_wrapper_backup "$rcfile")" || {
+    SHELL_WRAPPER_ERROR="could not back up $rcfile before editing it"
+    return 1
+  }
+  # shellcheck disable=SC2034 # public output var, read by callers after return
+  SHELL_WRAPPER_BACKUP="$backup"
+
+  tmp="$(mktemp)" || { SHELL_WRAPPER_ERROR="could not create a temp file"; return 1; }
+  awk -v begin="$SHELL_WRAPPER_MARKER_BEGIN" -v end="$SHELL_WRAPPER_MARKER_END" '
+    $0 == begin { skip = 1; next }
+    $0 == end   { skip = 0; next }
+    !skip { print }
+  ' "$rcfile" >"$tmp"
+
+  if ! mv "$tmp" "$rcfile"; then
+    rm -f "$tmp"
+    # shellcheck disable=SC2034 # public output var, read by callers after return
+    SHELL_WRAPPER_ERROR="could not move the rewritten file into place (backup: $backup)"
+    return 1
+  fi
+  return 0
+}

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -26,6 +26,30 @@ MARKER_END='<!-- END REPO-SKILLS -->'
 # shellcheck source=lib/claude-md-block.sh
 source "$SOURCE_ROOT/lib/claude-md-block.sh"
 
+# Shell `claude` wrapper removal (repo#35) — shared with install.sh's
+# --shell-wrapper opt-in.
+# shellcheck source=lib/shell-wrapper.sh
+source "$SOURCE_ROOT/lib/shell-wrapper.sh"
+
+# Candidate shell rc files that might carry our claude wrapper block, checked
+# regardless of the CURRENT $SHELL: the shell active at uninstall time may
+# differ from whichever was active when --shell-wrapper was installed, and
+# unlike install (which targets exactly one detected shell) uninstall's job is
+# to leave no orphaned block anywhere it could plausibly have landed.
+SW_CANDIDATES=()
+SW_ZSH_RC="$(shell_wrapper_rc_path zsh 2>/dev/null || true)"
+[[ -n "$SW_ZSH_RC" ]] && SW_CANDIDATES+=("$SW_ZSH_RC")
+SW_BASH_RC="$(shell_wrapper_rc_path bash 2>/dev/null || true)"
+[[ -n "$SW_BASH_RC" ]] && SW_CANDIDATES+=("$SW_BASH_RC")
+
+sw_any_present() {
+  local f
+  for f in "${SW_CANDIDATES[@]}"; do
+    shell_wrapper_block_present "$f" && return 0
+  done
+  return 1
+}
+
 # The PreToolUse guard command install.sh wires into .claude/settings.json. The
 # hook *script* lives under .claude/skills/repo/hooks/ and is removed with the
 # skills dir below; only this settings.json entry needs explicit removal.
@@ -124,6 +148,12 @@ if [[ -f "$TARGET/.claude/settings.json" ]] && \
      "$TARGET/.claude/settings.json" >/dev/null 2>&1; then
   echo "  .claude/settings.json SessionStart handoff entry"
 fi
+if sw_any_present; then
+  echo "Will also remove (outside $TARGET — your shell rc, from an earlier --shell-wrapper opt-in):"
+  for f in "${SW_CANDIDATES[@]}"; do
+    shell_wrapper_block_present "$f" && echo "  $f REPO-SKILLS CLAUDE WRAPPER block"
+  done
+fi
 
 if [[ "$YES" != true ]]; then
   read -r -p "Proceed? [y/N] " reply
@@ -141,6 +171,19 @@ if command -v jq >/dev/null 2>&1; then
 fi
 
 rmdir "$TARGET/.claude/skills" "$TARGET/.claude/commands" "$TARGET/.claude" 2>/dev/null || true
+
+# claude shell wrapper block, if a previous install opted in via
+# --shell-wrapper. Backed up before every edit, same as the CLAUDE.md surgery
+# above; no-op per candidate rc when our block isn't present there.
+for f in "${SW_CANDIDATES[@]}"; do
+  if shell_wrapper_block_present "$f"; then
+    if shell_wrapper_uninstall "$f"; then
+      success "Removed claude shell wrapper from $f (backed up to $SHELL_WRAPPER_BACKUP)"
+    else
+      warning "Could not remove the claude shell wrapper from $f: $SHELL_WRAPPER_ERROR"
+    fi
+  fi
+done
 
 if [[ -f "$TARGET/CLAUDE.md" ]] && grep -qF "$MARKER_BEGIN" "$TARGET/CLAUDE.md"; then
   if claude_md_block_rewrite "$TARGET/CLAUDE.md" "$MARKER_BEGIN" "$MARKER_END"; then


### PR DESCRIPTION
## Summary

`install.sh` gains `--shell-wrapper`: an opt-in edit to the user's shell rc (`~/.zshrc` or `~/.bashrc`) that defines a `claude` function printing a compact banner — note path, age, a `##`-header outline, a STALE warning past seven days — when a pending `/repo:handoff` note exists, *before* Claude starts. This is the "human sees it" half of the handoff workflow; the `SessionStart` hook shipped in #34 already covers the "Claude sees it" half.

This was deferred out of #32/#34 specifically because it is the one thing the installer writes **outside** the target repository, so it ships behind a hard opt-in/backup/diff-preview contract rather than folded into the unconditional install steps.

## Changes

- `lib/shell-wrapper.sh` (new): shell detection (`$SHELL`/`$ZSH_VERSION`/`$BASH_VERSION`; fish is skipped with a clear message, not half-supported), single-line `alias claude=...` parsing (extracts flags, folds them into the new function's `command claude` call), and marker-bounded (`# BEGIN REPO-SKILLS CLAUDE WRAPPER` / `# END ...`) rc surgery with backup-before-edit, mirroring `lib/claude-md-block.sh`'s discipline.
- `install.sh`: new `--shell-wrapper` flag; a new gated step (3e) that is a **strict no-op** under `--yes` without the flag, otherwise always shows the pending rc diff first and offers a confirm (default **N**) unless the flag was passed explicitly. `--dry-run` and usage text updated.
- `uninstall.sh`: removes the block (backed up) from any candidate rc it finds it in (`~/.zshrc`, `~/.bashrc`, regardless of the shell active at uninstall time); no-op when absent.
- `hooks/repo/tests/test-shell-wrapper.sh` (new): 55-case suite — unit tests for detection/parsing, install.sh integration fixtures (alias preservation, idempotency, missing rc, fish skip, unparseable-alias bail, ambiguous-marker guard, `--dry-run`), uninstall round-trip, and **runtime** tests that actually source the rendered function block and exercise `_repo_claude_handoff_banner`/`_repo_claude_is_session`/`claude()` against fixture repos (fresh note, stale note, no note, non-git cwd, argv passthrough, missing-helpers fail-transparent path) — registered in `hooks/repo/tests/run.sh`.
- `README.md`: documents the flag, the default-off behavior, the alias-preservation contract, and the uninstall path.

### Design note: fail-transparent by construction

A comment on #35 reported a *different*, non-reference wrapper breaking `claude mcp list` in a non-interactive shell because a helper function it depended on (`_claude_build_argv`) wasn't defined, and the wrapper then mangled argv. This implementation avoids that failure mode structurally: every helper (`_repo_claude_is_session`, `_repo_claude_handoff_banner`) is defined in the *same* marker-bounded block as `claude()` (so a shell that sources the rc gets all of it or none of it), the banner call is gated behind a `type` check, and `command claude <preserved-flags> "$@"` runs unconditionally regardless of whether the banner fired — so argv is never altered by whether helpers are present. Covered by an explicit test (`missing helpers -> transparent passthrough, argv unchanged`).

## Acceptance Criteria Verification

| Criterion (from issue #35 / Curator comment) | Status | Verification |
|---|---|---|
| `--shell-wrapper` flag; interactive mode also offers via confirm (default N), diff shown first | ✅ | `install.sh` §3e; manually verified diff output + confirm gating |
| Strict no-op under `--yes` without `--shell-wrapper` (rc neither read nor written) | ✅ | `strict no-op: .zshrc byte-identical` test |
| Marker-bounded, idempotent block | ✅ | `exactly one marker pair after re-install`, `idempotent re-install (byte-identical)` |
| rc backed up before first edit | ✅ | `backup file exists` / `backup holds the pre-edit content` |
| Existing alias parsed, flags folded in, `unalias claude` precedes the function, user's alias line outside the markers never edited | ✅ | `alias-preserve` test block (5 assertions) incl. textual-order check |
| Function invokes `command claude` (no recursion) | ✅ | `claude() invokes 'command claude', passing argv through` |
| Banner gated on session-starting invocations only (`update\|doctor\|mcp\|config\|install\|migrate-installer\|setup-token`, `-v\|--version\|-h\|--help`) | ✅ | `_repo_claude_is_session gates the documented subcommand list` |
| Portable mtime (BSD `stat -f %m` / GNU `stat -c %Y`, reused from `session-start-handoff.sh`) | ✅ | Same fallback pattern in the rendered banner; runtime fresh/stale tests pass on this (macOS/BSD) host |
| zsh + bash supported; fish skipped with a clear message, rc untouched | ✅ | `fish-skip` test |
| `uninstall.sh` removes the block (backed up), no-op when absent | ✅ | `uninstall-roundtrip` (removal + byte-identical restore) + second-run no-op test |
| Banner matches #32 reference: path, age label, `##`-header outline (≤9 lines), STALE at ≥7 days | ✅ | Runtime tests: fresh note (header/path/age/outline, no STALE), stale note (STALE present) |
| README documents the flag, default-off behavior, uninstall path | ✅ | New "Optional: surface the note to the human too" section |

## Test Plan

- `pnpm test` (full suite, `hooks/repo/tests/run.sh`): new `test-shell-wrapper.sh` suite passes 55/55, folded into the aggregate per the existing delegated-suite pattern. The only failures observed anywhere in the full run are 8 flaky cases inside `test-guard-destructive.sh` (force-push/reset-hard/decision-log assertions), independently reproduced on `origin/main` with zero changes from this branch — pre-existing and unrelated to this PR.
- `shellcheck -x` on `install.sh`, `uninstall.sh`, `lib/shell-wrapper.sh`, `hooks/repo/tests/test-shell-wrapper.sh`, `hooks/repo/tests/run.sh`: no warnings beyond the same info-level notices (`SC2094`, `SC2016`, `SC1091` cross-file source) already present elsewhere in this codebase.
- Manual end-to-end runs against scratch `$HOME`/target-repo fixtures: `--yes` alone (no-op confirmed byte-identical), `-y --shell-wrapper` with a pre-existing `alias claude='command claude --dangerously-skip-permissions'` (flag preserved, backup created, idempotent re-run), `SHELL=fish` (clean skip, no rc created), and `uninstall.sh -y` (block removed, rc restored to original content).
- Rebased cleanly onto `origin/main` (post #61/#62/#63); re-ran the full suite after rebase (results above).

Closes #35