### PR TITLE
fix(gitignore): match node_modules symlink by dropping trailing slash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 .DS_Store
 
 # Dependencies
-node_modules/
+node_modules
 
 # Repo Skills dev-mode symlinks (machine-local, do not commit)
 .claude/


### PR DESCRIPTION
## Summary

Changes the `.gitignore` dependency pattern from `node_modules/` (directory-only) to `node_modules` (no trailing slash) so it matches both the real `node_modules` directory in the main checkout and the `node_modules` symlink that `./.loom/scripts/worktree.sh` creates in every issue worktree. Previously each worktree showed `node_modules` as untracked, adding noise that every builder had to reason about (flagged independently by the issue-48 and issue-53 builders during the 2026-07-29 sweep) and risking an accidental `git add -A` committing the symlink.

## Changes

- `.gitignore`: `node_modules/` -> `node_modules` (line 4). No other lines touched; the pattern stays outside the `>>> loom-managed >>>` block, so it survives Loom updates. Per the scope guard, `.loom/scripts/worktree.sh` (upstream-owned) is intentionally NOT modified.

## Acceptance Criteria Verification

- [x] `.gitignore` pattern changed from `node_modules/` to `node_modules` (single-line diff; nothing else changed; stays outside the loom-managed block)
- [x] `git check-ignore -q node_modules` passes in the main checkout (real directory still ignored)
- [x] `git check-ignore -q node_modules` passes against a symlink (verified in the issue worktree, whose `node_modules` is a symlink, and independently in a scratch repo under `$TMPDIR`)
- [x] In this worktree (created by `worktree.sh`), `git status --porcelain` no longer lists `node_modules` (only ` M .gitignore` appears)

## Test Plan

- Worktree symlink context: `git check-ignore -v node_modules` -> `.gitignore:4:node_modules` (match); `git status --porcelain` no longer lists `node_modules`.
- Scratch repo (`$TMPDIR`): with the new pattern, both a `node_modules` symlink and a real `node_modules` directory are ignored; `git status --porcelain` stays empty for both.
- Full suite: `CI=true pnpm test` -> PASS: 782, FAIL: 0.

Closes #59