### PR TITLE
feat(sudo): add /repo:sudo passwordless-sudo setup command

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Repo is a collection of skills for keeping any git repository healthy and produc
 | `/repo:tidy` | Tidy up — build artifacts, caches, temp files, empty dirs |
 | `/repo:release` | Cut a release — pre-flight checks, semver decision, CHANGELOG, version bump, tag, GitHub Release |
 | `/repo:remote` | Launch a cloud dev session (GCP or AWS) with the repo ready to go, then open an SSH session |
+| `/repo:sudo` | Opt-in passwordless-sudo setup for a dev machine — install a `visudo`-validated `/etc/sudoers.d` drop-in (blanket `ALL` or a scoped command list) so an agent over SSH isn't blocked on password prompts; always confirmed, validated with rollback on failure |
 | `/repo:host-optimize` | Prepare a Mac (or Linux box) for heavy Loom/agent build use — audit Gatekeeper churn, backup-agent interference, build-tree bloat; apply safe fixes, gate consequential ones |
 | `/repo:update-tools` | Check installed tool packages (Loom, Anvil, …) against their sources and offer updates |
 | `/repo:followups` | Capture follow-on work from this session and file it as issues — here or in upstream tool repos, always confirmed first |
@@ -28,7 +29,7 @@ Repo is a collection of skills for keeping any git repository healthy and produc
 | `/repo:orphans` | Find unreferenced files — dead scripts, stale data, outputs without sources |
 | `/repo:readme` | Check README accuracy against actual directory contents |
 
-Hygiene skills **apply their safe, reversible fixes by default** and report each change; add `--ask` to review findings and confirm first. Irreversible actions (deleting branches, worktrees, stashes, untracked files) are never automatic — they require an explicit opt-in and pass a permanent-loss check. Commands whose only action is consequential (`orphans`, `update-tools`, `followups`, `release`, `remote`) always confirm first.
+Hygiene skills **apply their safe, reversible fixes by default** and report each change; add `--ask` to review findings and confirm first. Irreversible actions (deleting branches, worktrees, stashes, untracked files) are never automatic — they require an explicit opt-in and pass a permanent-loss check. Commands whose only action is consequential (`orphans`, `update-tools`, `followups`, `release`, `remote`, `sudo`) always confirm first.
 
 ## Destructive-command protection
 

--- a/commands/repo/help.md
+++ b/commands/repo/help.md
@@ -60,6 +60,7 @@ stashes, untracked files) always need an explicit opt-in.
 | /repo:handoff | Rolling the session (context full, CLI update) — preserve what only the session knows, then restart |
 | /repo:tidy  | Working tree cluttered with build artifacts and temp files |
 | /repo:remote | Need a cloud dev box (GCP/AWS) with this repo ready to go |
+| /repo:sudo | One-time machine setup — grant passwordless sudo (validated drop-in) so an agent over SSH isn't blocked on password prompts |
 | /repo:release | Cut a release — pre-flight, semver, CHANGELOG, version bump, tag, GitHub Release |
 
 ### Periodic maintenance

--- a/commands/repo/remote.md
+++ b/commands/repo/remote.md
@@ -468,6 +468,10 @@ Claude Code cannot host an interactive SSH session itself, so hand it to the OS
   terminal
 
 Tell the user they can start `claude` in that session to continue on the remote.
+On a freshly provisioned box, `/repo:sudo` is the companion step that unblocks
+root-level remediation over SSH — a non-interactive SSH session can't answer a
+`sudo` password prompt, so an agent stalls on it until a validated
+passwordless-sudo drop-in is installed.
 
 ### 8. Report
 

--- a/commands/repo/sudo.md
+++ b/commands/repo/sudo.md
@@ -64,9 +64,12 @@ needed**:
 - **Linux** — nearly every distro ships `#includedir /etc/sudoers.d` in
   `/etc/sudoers`.
 
-Running `sudo visudo -c` after the write implicitly proves the include chain is
-active on either platform (it validates `/etc/sudoers` **and** every file it
-includes), so there is no need to detect the OS or hand-verify the directive.
+The candidate file is always syntax-checked **in isolation** with
+`sudo visudo -cf "$TMP"` *before* it is copied into `/etc/sudoers.d/` — a
+malformed drop-in never becomes live policy. After the validated file is
+installed, a full-chain `sudo visudo -c` (it validates `/etc/sudoers` **and**
+every file it includes) implicitly proves the include chain is active on either
+platform, so there is no need to detect the OS or hand-verify the directive.
 
 The written file always carries a **discoverability header** on its first line
 so `--status`, `--remove`, and any later host-posture audit (e.g.
@@ -174,9 +177,15 @@ Always show the **exact file contents** (including the header line) that will be
 written, name the target path, and get an explicit **yes** before touching
 anything — even without `--ask`. Never write silently.
 
-Build the file in a temp location, copy it into place at `0440`, then validate
-— and **remove it on any validation failure** so a typo can never leave `sudo`
-broken (a malformed sudoers file can lock the user out of root):
+Build the file in a temp location and **validate the candidate in isolation
+before it can go live** — only a syntactically valid file is ever copied into
+`/etc/sudoers.d/`. There is no separate "enable" step for a sudoers.d file: the
+`@includedir` / `#includedir` directive picks it up on the very next `sudo`
+parse, so a broken file that reaches the directory is *already* live policy —
+and because sudo fails closed on a syntax error, the rollback `sudo rm` could be
+denied by the very file it is trying to remove. Validating `$TMP` first makes
+that failure mode impossible; the post-install full-chain check is then only a
+belt-and-suspenders proof that the include wiring is sound:
 
 ```bash
 USER_NAME="$(id -un)"
@@ -193,23 +202,38 @@ TMP="$(mktemp)"
 } > "$TMP"
 chmod 440 "$TMP"
 
+# Validate the candidate BEFORE it can affect live policy. visudo -cf checks a
+# single file's syntax without installing it, so a malformed drop-in never
+# becomes active and we never depend on a possibly-broken sudo to undo it.
+if ! sudo visudo -cf "$TMP"; then
+  rm -f "$TMP"
+  echo "candidate sudoers failed validation — nothing installed" >&2
+  exit 1
+fi
+
+# Only a validated file reaches /etc/sudoers.d/:
 sudo cp "$TMP" "$DROPIN"
 sudo chmod 440 "$DROPIN"
 rm -f "$TMP"
 
-# ALWAYS validate before reporting success. On failure, remove the drop-in and
-# exit non-zero — never leave an unvalidated or broken file in place.
+# Belt-and-suspenders: full-chain re-check proves the include wiring too. If it
+# somehow fails, remove the drop-in and exit non-zero — never leave an
+# unvalidated or broken file in place. (This rollback is now reliable because
+# the file was already known-valid before it landed.)
 if ! sudo visudo -c; then
   sudo rm -f "$DROPIN"
-  echo "sudoers validation failed — removed ${DROPIN}, no change made" >&2
+  echo "post-install validation failed — removed ${DROPIN}, no change made" >&2
   exit 1
 fi
 ```
 
-The order is load-bearing: the file is written at `0440`, and `visudo -c` is
-the last gate before success. If it fails for **any** reason, the drop-in is
-deleted and the command exits non-zero — there is no path in which a
-failed-validation file survives.
+The order is load-bearing: the candidate is syntax-checked with
+`visudo -cf "$TMP"` **before** the `cp`, so a malformed drop-in never becomes
+live policy and the rollback never has to fight a broken sudo. The post-install
+`visudo -c` is the final full-chain gate; if it fails for **any** reason the
+drop-in is deleted and the command exits non-zero — there is no path in which a
+failed-validation file survives, and no path in which an unvalidated file goes
+live even momentarily.
 
 ### 6. Verify and report
 
@@ -230,11 +254,16 @@ it later.
 1. **Always confirm before writing** — show the exact file contents (header +
    grant line) and the target path, and act only on an explicit yes. There is
    no silent/auto-apply mode; confirmation is the only mode.
-2. **Always validate, always roll back on failure** — the drop-in is written at
-   `0440` and `sudo visudo -c` runs before the command reports success. On any
-   validation failure the file is removed and the command exits non-zero. A
-   broken sudoers file can lock the user out of root, so an unvalidated file is
-   never left behind.
+2. **Validate the candidate before it goes live, then roll back on failure** —
+   the candidate is built at `0440` in a temp file and syntax-checked in
+   isolation with `sudo visudo -cf "$TMP"` **before** it is copied into
+   `/etc/sudoers.d/`, so a malformed drop-in never becomes active policy (a
+   sudoers.d file is live the instant it lands, and sudo fails closed on a
+   syntax error — validating pre-install is what keeps the rollback reliable). A
+   post-install full-chain `sudo visudo -c` then re-checks the include wiring;
+   on any failure the file is removed and the command exits non-zero. A broken
+   sudoers file can lock the user out of root, so an unvalidated file is never
+   installed or left behind.
 3. **Idempotent** — re-running with the same scope detects the existing drop-in
    and no-ops; only a scope *change* prompts to overwrite.
 4. **Only ever touch this command's own drop-in** at

--- a/commands/repo/sudo.md
+++ b/commands/repo/sudo.md
@@ -1,0 +1,246 @@
+---
+name: "sudo"
+description: "Opt-in passwordless sudo for a dev machine — install a visudo-validated /etc/sudoers.d drop-in (ALL or a scoped command list) so an agent over SSH isn't blocked on password prompts, always confirmed first"
+domain: repo
+type: command
+user-invocable: true
+---
+
+# /repo:sudo — Passwordless-sudo setup for dev machines
+
+Install (or inspect, or remove) a `NOPASSWD:` **sudoers drop-in** for the
+current user on **this machine**, so an agent driving the box over SSH isn't
+stopped dead by a `sudo` password prompt it can't answer. A non-interactive SSH
+session has no TTY to type a password into, so every root-level remediation —
+`launchctl bootout`, killing a runaway root process, `spctl`, `renice` — stalls
+until a human runs the command by hand. This command installs the standard fix
+once, safely, so agent-driven remote sessions can finish end-to-end.
+
+This is **machine-global, consequential setup**: the drop-in grants anyone
+holding the user's SSH key effective root on this box. It is therefore in the
+same **always-confirm-first** class as `/repo:remote`, `/repo:followups`, and
+`/repo:update-tools` — it shows the **exact file contents** it will write and
+**never applies silently**, even without `--ask`. There is nothing to opt into;
+confirmation is the only mode. The reasonable trade this makes — passwordless
+root for personal dev machines on a private tailnet — is a deliberate operator
+choice, so the operator makes it explicitly every time a scope changes.
+
+> **Touch ID is the better answer for *local, interactive* use** — enabling
+> `pam_tid.so` in `/etc/pam.d/sudo` lets a Mac authorize `sudo` with a
+> fingerprint. But Touch ID does **not** work over SSH (there is no local
+> fingerprint reader on the remote end), which is exactly why a `NOPASSWD:`
+> drop-in is the right tool for **agent sessions** and this command exists.
+
+The **destructive-command guard still applies on top.** Passwordless sudo
+removes the *password* gate, not the guard's `ask`/`block` gates on risky
+commands (`rm -rf /`, force-push to `main`, cloud destruction, …). Granting
+passwordless root does not weaken any of those checks.
+
+## Usage
+
+```
+/repo:sudo                 # Guided: explain the grant, confirm, install an ALL-scoped drop-in
+/repo:sudo --scoped        # Confirm, then install a command-list-scoped drop-in
+                            #   (launchctl, pkill, spctl, renice, …) instead of ALL
+/repo:sudo --status        # Report whether a drop-in exists, its scope, and validity — writes nothing
+/repo:sudo --remove        # Confirm, then remove this command's drop-in file
+```
+
+## How it works
+
+The drop-in lives at a well-known, per-user path — **the file itself is the
+marker**:
+
+```
+/etc/sudoers.d/<user>-nopasswd
+```
+
+Both macOS and Linux read this directory automatically, so **no OS branching is
+needed**:
+
+- **macOS** — `/etc/sudoers` (a symlink target of `/private/etc/sudoers`)
+  ships `@includedir /private/etc/sudoers.d` by default, and `/etc/sudoers.d`
+  is `/private/etc/sudoers.d`.
+- **Linux** — nearly every distro ships `#includedir /etc/sudoers.d` in
+  `/etc/sudoers`.
+
+Running `sudo visudo -c` after the write implicitly proves the include chain is
+active on either platform (it validates `/etc/sudoers` **and** every file it
+includes), so there is no need to detect the OS or hand-verify the directive.
+
+The written file always carries a **discoverability header** on its first line
+so `--status`, `--remove`, and any later host-posture audit (e.g.
+`/repo:host-optimize`) can find and attribute it without guessing from the
+filename:
+
+```
+# Installed by /repo:sudo (rjwalters/repo) — see .claude/commands/repo/sudo.md
+```
+
+Two scopes are supported:
+
+- **ALL** (default) — blanket passwordless root:
+
+  ```
+  <user> ALL=(ALL) NOPASSWD: ALL
+  ```
+
+- **Scoped** (`--scoped`) — passwordless only for a small allowlist of
+  service-management commands, so agents are unblocked on the operations that
+  actually stall over SSH without granting blanket root:
+
+  ```
+  <user> ALL=(ALL) NOPASSWD: /bin/launchctl, /usr/bin/pkill, /usr/sbin/spctl, /usr/bin/renice
+  ```
+
+  Anything outside that list still prompts for a password. Adjust the allowlist
+  to what the machine actually needs before confirming.
+
+## Steps
+
+### 1. Resolve the target and read current state
+
+Resolve the drop-in path and read what's already installed — every mode below
+starts here, and it is the whole of `--status`.
+
+```bash
+USER_NAME="$(id -un)"
+DROPIN="/etc/sudoers.d/${USER_NAME}-nopasswd"
+
+if [ -f "$DROPIN" ] || sudo test -f "$DROPIN" 2>/dev/null; then
+  CURRENT="$(sudo cat "$DROPIN" 2>/dev/null)"        # readable only as root (0440)
+else
+  CURRENT=""
+fi
+```
+
+Classify the installed scope from `$CURRENT`, ignoring the header/comment lines:
+
+- **absent** — no file.
+- **ALL** — the effective grant is `NOPASSWD: ALL`.
+- **scoped** — the effective grant is a `NOPASSWD:` command list.
+
+Determine the **requested** scope from the flags: `--scoped` → scoped list;
+otherwise → ALL. (`--status` and `--remove` don't request a scope.)
+
+### 2. `--status` — report only, write nothing
+
+Report and **stop** — this mode never writes, never prompts, and must not
+change the file's mtime:
+
+- Whether `$DROPIN` exists, and its scope (ALL vs. the scoped command list).
+- Whether it currently passes validation — run `sudo visudo -c` and report
+  pass/fail (this reads the config; it does not modify it).
+- Whether passwordless sudo is actually in effect right now:
+  `sudo -n true 2>/dev/null && echo 'passwordless sudo works' || echo 'sudo still requires a password'`.
+
+Then exit. Do not fall through to any write path.
+
+### 3. `--remove` — delete this command's drop-in (confirm first)
+
+Only ever remove **this command's own** file at `$DROPIN` (identified by the
+header from step 1) — never touch other files in `/etc/sudoers.d/`.
+
+1. If the file is absent, say so and stop (nothing to remove — idempotent).
+2. Show the file that will be deleted and its current contents, and get an
+   explicit **yes**.
+3. Remove it, then re-validate so the removal didn't break anything:
+
+   ```bash
+   sudo rm -f "$DROPIN"
+   sudo visudo -c
+   ```
+
+4. Confirm the effect: a subsequent `sudo` now prompts for a password again
+   (`sudo -n true` should fail). Report done.
+
+### 4. Idempotency check (install modes)
+
+Before writing anything, compare the **installed** scope (step 1) against the
+**requested** scope (step 2):
+
+- **Same scope already installed** → **no-op.** Report "already configured
+  (`<scope>`) at `$DROPIN`" and stop. Do not re-prompt and do not re-write —
+  re-running with the same scope must make no changes.
+- **Different scope installed** (e.g. `--scoped` requested but `ALL` is
+  installed, or vice-versa) → this is a real change of the grant. Say so
+  explicitly ("currently `ALL`; you asked for `scoped`"), and require
+  confirmation in step 5 before overwriting.
+- **Nothing installed** → proceed to step 5 as a fresh install.
+
+### 5. Confirm, then write / validate / roll back
+
+Always show the **exact file contents** (including the header line) that will be
+written, name the target path, and get an explicit **yes** before touching
+anything — even without `--ask`. Never write silently.
+
+Build the file in a temp location, copy it into place at `0440`, then validate
+— and **remove it on any validation failure** so a typo can never leave `sudo`
+broken (a malformed sudoers file can lock the user out of root):
+
+```bash
+USER_NAME="$(id -un)"
+DROPIN="/etc/sudoers.d/${USER_NAME}-nopasswd"
+TMP="$(mktemp)"
+
+# Header first (discoverability), then the grant line for the chosen scope:
+{
+  echo "# Installed by /repo:sudo (rjwalters/repo) — see .claude/commands/repo/sudo.md"
+  # Default (ALL):
+  echo "${USER_NAME} ALL=(ALL) NOPASSWD: ALL"
+  # --scoped instead:
+  # echo "${USER_NAME} ALL=(ALL) NOPASSWD: /bin/launchctl, /usr/bin/pkill, /usr/sbin/spctl, /usr/bin/renice"
+} > "$TMP"
+chmod 440 "$TMP"
+
+sudo cp "$TMP" "$DROPIN"
+sudo chmod 440 "$DROPIN"
+rm -f "$TMP"
+
+# ALWAYS validate before reporting success. On failure, remove the drop-in and
+# exit non-zero — never leave an unvalidated or broken file in place.
+if ! sudo visudo -c; then
+  sudo rm -f "$DROPIN"
+  echo "sudoers validation failed — removed ${DROPIN}, no change made" >&2
+  exit 1
+fi
+```
+
+The order is load-bearing: the file is written at `0440`, and `visudo -c` is
+the last gate before success. If it fails for **any** reason, the drop-in is
+deleted and the command exits non-zero — there is no path in which a
+failed-validation file survives.
+
+### 6. Verify and report
+
+On success, prove the grant actually took and report a compact block:
+
+```bash
+sudo -n true 2>/dev/null && echo 'passwordless sudo now works' \
+                         || echo 'WARNING: drop-in written and validated but sudo -n still prompts'
+```
+
+Report: the path written, the scope (ALL vs. the scoped list, with the exact
+command list for the scoped case), that permissions are `0440`, that
+`visudo -c` passed, and the removal command (`/repo:sudo --remove`) for undoing
+it later.
+
+## Safety Rules
+
+1. **Always confirm before writing** — show the exact file contents (header +
+   grant line) and the target path, and act only on an explicit yes. There is
+   no silent/auto-apply mode; confirmation is the only mode.
+2. **Always validate, always roll back on failure** — the drop-in is written at
+   `0440` and `sudo visudo -c` runs before the command reports success. On any
+   validation failure the file is removed and the command exits non-zero. A
+   broken sudoers file can lock the user out of root, so an unvalidated file is
+   never left behind.
+3. **Idempotent** — re-running with the same scope detects the existing drop-in
+   and no-ops; only a scope *change* prompts to overwrite.
+4. **Only ever touch this command's own drop-in** at
+   `/etc/sudoers.d/<user>-nopasswd` (identified by its `Installed by /repo:sudo`
+   header) — never other files in `/etc/sudoers.d/`.
+5. **The destructive-command guard still applies** — passwordless sudo removes
+   the password gate, not the guard's `ask`/`block` gates on risky commands.
+6. **Prefer the smallest grant that unblocks the work** — offer `--scoped`
+   (launchctl / pkill / spctl / renice) when blanket `ALL` root isn't needed.

--- a/skills/repo/SKILL.md
+++ b/skills/repo/SKILL.md
@@ -14,7 +14,7 @@ each change; add `--ask` to review findings and confirm first. Anything
 irreversible — deleting a branch, worktree, stash, or untracked file — is never
 automatic: it takes an explicit opt-in and passes a permanent-loss check.
 Commands whose only action is consequential (`orphans`, `update-tools`,
-`followups`, `release`, `remote`) always confirm first by nature. The environment commands (`remote`) stand up
+`followups`, `release`, `remote`, `sudo`) always confirm first by nature. The environment commands (`remote`) stand up
 infrastructure only after showing exactly what they will create and what it
 costs.
 
@@ -31,6 +31,7 @@ costs.
 | [[release]] | Cut a release — pre-flight, semver decision, CHANGELOG, version bump, tag, GitHub Release |
 | [[host-optimize]] | Prepare a Mac (or Linux box) for heavy Loom/agent build use — audit Gatekeeper churn, backup-agent interference, build-tree bloat; apply safe fixes, gate consequential ones |
 | [[remote]] | Launch a cloud dev session (GCP or AWS) with this repo ready to go, then open SSH. Its provisioning contract is implemented once in `scripts/repo/repo-remote.sh` (installed to `.claude/skills/repo/scripts/`); the interactive flow delegates to that script, which also serves as a headless `repo-remote up --yes --json` entry point for non-interactive callers (e.g. loom's `fleet add-worker`) |
+| [[sudo]] | Opt-in passwordless-sudo setup for a dev machine — install a `visudo`-validated `/etc/sudoers.d` drop-in (blanket `ALL` or a scoped command list) so an agent over SSH isn't blocked on password prompts; always confirmed first, validated with rollback on failure |
 | [[update-tools]] | Check installed tool packages (Loom, Anvil, …) against their sources and offer updates |
 | [[followups]] | Capture follow-on work from this session and file it as issues — here or in upstream tool repos, always confirmed first |
 | [[branches]] | Branch & worktree hygiene — merged PRs, orphaned branches, stale worktrees |
@@ -48,6 +49,7 @@ costs.
 - When `git branch` output has grown unmanageable (`branches`)
 - When local hardware isn't enough or you need a clean Linux box (`remote`)
 - Before turning a Mac into a heavy Loom/agent build host (`host-optimize`)
+- To unblock an agent driving a dev box over SSH from `sudo` password prompts (`sudo`)
 - Periodically, to keep installed tool packages current (`update-tools`)
 - Periodically (monthly) as general hygiene (`audit`)
 - Before a demo, handoff, or onboarding (clean up before they arrive)


### PR DESCRIPTION
## Summary

Adds a dedicated **`/repo:sudo`** command that installs an opt-in,
`visudo`-validated `/etc/sudoers.d/<user>-nopasswd` drop-in so an agent driving a
dev machine over SSH isn't blocked on `sudo` password prompts a non-interactive
session can't answer. Machine-global, consequential setup in the always-confirm
class (like `/repo:remote`, `/repo:followups`, `/repo:update-tools`): it shows
the exact file contents before writing and never applies silently.

## Changes

- **`commands/repo/sudo.md`** (new) — the command. Surface:
  - `/repo:sudo` — guided, installs a blanket `NOPASSWD: ALL` drop-in
  - `/repo:sudo --scoped` — installs a `NOPASSWD:` grant limited to a command
    allowlist (`/bin/launchctl`, `/usr/bin/pkill`, `/usr/sbin/spctl`,
    `/usr/bin/renice`)
  - `/repo:sudo --status` — reports presence, scope, and `visudo -c` validity;
    writes nothing
  - `/repo:sudo --remove` — deletes this command's own drop-in after confirmation

  Write sequence builds to a temp file, copies into place at `0440`, then always
  runs `sudo visudo -c` with **delete-on-failure and non-zero exit** so a broken
  sudoers file is never left behind. Idempotent per-scope (same scope no-ops; a
  scope *change* prompts to overwrite). The drop-in carries an
  `# Installed by /repo:sudo (rjwalters/repo)` discoverability header. No OS
  branching — both macOS and Linux read `/etc/sudoers.d/`, and `visudo -c` proves
  the include chain on either. Documents that Touch ID is the better local answer
  but doesn't work over SSH, and that the destructive-command guard still applies.
- **`skills/repo/SKILL.md`** — `[[sudo]]` row (machine-setup cluster, after
  `[[remote]]`), a When-to-Use bullet, and `sudo` added to the consequential list.
- **`commands/repo/help.md`** — `/repo:sudo` in the Everyday bucket.
- **`README.md`** — `/repo:sudo` row and consequential list updated.
- **`commands/repo/remote.md`** — optional companion cross-reference to
  `/repo:sudo` for a freshly provisioned box.

## Acceptance Criteria Verification

- [x] New `commands/repo/sudo.md` with standard frontmatter + Usage/Steps
- [x] Default writes `/etc/sudoers.d/<user>-nopasswd` `NOPASSWD: ALL`, confirmed with exact contents shown
- [x] `--scoped` writes the command-allowlist grant, confirmed the same way
- [x] Perms always `0440`; `sudo visudo -c` always runs before success; delete-on-failure with non-zero exit (no path leaves a broken/unvalidated file)
- [x] Re-run same scope is idempotent (no re-prompt, no re-write)
- [x] Re-run different scope prompts before overwriting
- [x] `--status` reports presence/scope/validity, writes nothing
- [x] `--remove` deletes only this command's drop-in, after confirmation
- [x] Drop-in carries the `Installed by /repo:sudo` header
- [x] Works on macOS and Linux (shared `/etc/sudoers.d/` mechanism, no OS branch)
- [x] `SKILL.md`, `help.md`, `README.md` each gain a `/repo:sudo` entry

## Test Plan

- [x] `pnpm test` — **782 pass, 0 fail** (unchanged; the suites cover the guard
  hooks and scripts, and the new command is prose with no harness of its own).
- Manual sudoers verification is inherently machine-mutating and left to the
  operator per the issue's Test Plan; the write/validate/rollback ordering is
  verifiable by implementation review of Step 5.

Closes #49