### PR TITLE
feat(release): add per-project release policy seams to /repo:release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,17 @@
   assume nothing was written: **correct the markers so exactly one BEGIN and one
   END exist, in that order, then re-run the installer** (which reconciles the
   now-valid block). CLAUDE.md itself is never modified by a refused run.
+- **`/repo:release` now supports per-project release policy at named phase
+  boundaries (#43).** A repo can inject its own procedural steps — gates, extra
+  manifest edits, post-release deploys — via a single `.repo/release-policy.md`
+  file with `## seam: <name>` sections, without forking the 269-line command.
+  Seven seams are exposed (`pre-flight`, `pre-changelog-style`, `pre-apply`,
+  `pre-push`, `post-push`, `pre-github-release`, `post-summary`); steps augment
+  the phase by default, or replace its default action with a `(replace)` marker.
+  A new Phase 0 loads the file and **warns before Phase 1 on any seam name that
+  binds to no phase boundary**, closing the silent-failure mode that orphaned
+  policy migrating off Loom's removed `/loom:release` skill (all five of its old
+  seam names carry over unchanged).
 
 ## 0.6.1 (2026-07-27)
 

--- a/commands/repo/release.md
+++ b/commands/repo/release.md
@@ -19,10 +19,66 @@ at release time, never hardcoded, so this works in any repo.
 /repo:release                  # Interactive release from the default branch
 ```
 
+## Phase 0 — Load project release policy
+
+Before Phase 1, load the repo's **release policy** if it has one. This is the
+single supported way for a project to inject its own procedural steps (gates,
+extra manifest edits, post-release deploys) at named phase boundaries without
+forking this command — see **Extension points — per-project release policy**
+below for the full seam contract and semantics. Projects migrating off Loom's
+removed `/loom:release` skill re-home their policy here.
+
+The policy lives in **one** file at the repo root: **`.repo/release-policy.md`**.
+Each seam is an H2 section headed `## seam: <name>`. Read it, then **validate the
+declared seam names and surface any that don't bind**, so a typo'd or orphaned
+seam fails loudly instead of silently doing nothing:
+
+```bash
+POLICY_FILE=".repo/release-policy.md"
+KNOWN_SEAMS="pre-flight pre-changelog-style pre-apply pre-push post-push pre-github-release post-summary"
+AUGMENT_ONLY="post-push post-summary"   # no default action → '(replace)' is meaningless
+if [ ! -f "$POLICY_FILE" ]; then
+  echo "(no $POLICY_FILE — running with the built-in phases only, no behavior change)"
+else
+  echo "Project release policy: $POLICY_FILE"
+  # Enumerate declared seams from '## seam: <name>' headers (dropping an optional
+  # '(replace)' suffix) and check each against the known set.
+  grep -E '^##[[:space:]]+seam:[[:space:]]*' "$POLICY_FILE" | while IFS= read -r header; do
+    name="$(printf '%s' "$header" | sed -E 's/^##[[:space:]]+seam:[[:space:]]*//; s/[[:space:]]*\(replace\)[[:space:]]*$//; s/[[:space:]]+$//')"
+    mode="augment"
+    printf '%s' "$header" | grep -Eq '\(replace\)[[:space:]]*$' && mode="replace"
+    case " $KNOWN_SEAMS " in
+      *" $name "*)
+        case " $AUGMENT_ONLY " in
+          *" $name "*)
+            if [ "$mode" = replace ]; then
+              echo "  WARNING: seam '$name' is augment-only — '(replace)' is meaningless here and will be ignored"
+            else
+              echo "  bound: $name (augment)"
+            fi ;;
+          *) echo "  bound: $name ($mode)" ;;
+        esac ;;
+      *)
+        echo "  WARNING: unknown seam '$name' — it matches no phase boundary and will NOT run. Fix the name (see the seam table) or remove the section." ;;
+    esac
+  done
+fi
+```
+
+If any `WARNING:` line prints, **stop and show it to the operator before Phase 1
+proceeds.** An unknown or misused seam is almost always a typo, or policy written
+against a seam this command doesn't expose — silently ignoring it is the exact
+failure this mechanism exists to prevent. Offer **[c]** continue anyway (the
+offending section simply won't run) or **[a]** abort to fix the policy. When the
+policy is clean, note which seams are bound and carry that into the phases below.
+
 ## Phase 1 — Pre-flight
 
 Confirm the repo is safe to cut from. The CI gate degrades gracefully when no
 workflows exist.
+
+> Seam `pre-flight` fires at the start of this phase — run any bound policy steps
+> before (augment) or in place of (replace) the checks below.
 
 ```bash
 # CI status, if CI exists at all
@@ -193,12 +249,19 @@ level and **ask the user to confirm or override.**
 
 ## Phase 4 — Draft the CHANGELOG
 
+> Seam `pre-changelog-style` fires before drafting — run any bound policy steps
+> to enforce a house changelog style (augment) or produce the entry itself
+> (replace).
+
 If `CHANGELOG.md` exists, study its format and draft a new entry matching it
 (header with today's date, a summary line, grouped changes, issue refs). If it's
 **absent**, offer to bootstrap a "Keep a Changelog" template. Present the draft
 and iterate until approved. Omit empty sections.
 
 ## Phase 5 — Apply
+
+> Seam `pre-apply` fires before this phase — run any bound policy steps (e.g.
+> edit extra manifests) before (augment) or in place of (replace) the bump.
 
 Once approved:
 
@@ -231,6 +294,11 @@ Show the result and get final confirmation.
 
 ## Phase 6 — Push & release
 
+Three seams fire in this phase: `pre-push` (before the push), `post-push`
+(immediately after it succeeds), and `pre-github-release` (before
+`gh release create`). Run any bound policy steps at each boundary — e.g. a
+`pre-github-release` gate that holds the Release until publish workflows finish.
+
 After an explicit yes:
 
 ```bash
@@ -259,11 +327,103 @@ CHANGELOG: 1 entry added
 Release:   GitHub Release created  (or: tag push only — no release workflow)
 ```
 
+> Seam `post-summary` fires after the summary — run any bound policy steps (e.g.
+> deploy a docs site, notify a channel).
+
+## Extension points — per-project release policy
+
+The phases above are fixed, but a project can inject its own procedural steps at
+**named phase boundaries** ("seams") without forking this command. This is what
+projects migrating off Loom's removed `/loom:release` skill use to re-home
+release policy — gates, extra manifest edits, post-release deploys.
+
+### Where policy lives
+
+**One** file, at the repo root: **`.repo/release-policy.md`**. There is a single
+supported lookup path by design — no per-user, per-branch, or fallback locations.
+Advisory *reminders* (e.g. "bump the protocol version when the API changes") still
+belong in the repo's CLAUDE.md, which this command already reads as context; the
+policy file is specifically for **procedural steps bound to a seam**.
+
+### Policy file format
+
+Each seam is an H2 section whose header is `## seam: <name>`, optionally suffixed
+with `(replace)`. The section body is the prose/steps the command runs at that
+boundary. Non-seam prose (a title, notes) is ignored — only `## seam:` headers
+bind.
+
+```markdown
+# Release policy — my-project
+
+## seam: pre-github-release
+
+Hold the GitHub Release until both publish workflows finish:
+- `gh run watch <npm-publish-run>` and `<crates-publish-run>` must both be green.
+
+## seam: post-summary
+
+Deploy the docs site: `gh workflow run deploy-site.yml`.
+
+## seam: pre-push (replace)
+
+Push via the release-bot identity instead of the default push:
+`git -c user.name="release-bot" push origin "$(git symbolic-ref --short HEAD)" --follow-tags`
+```
+
+### Seams and semantics
+
+Steps **augment** by default — they run *in addition to* the phase's built-in
+action, at the boundary. Appending `(replace)` to the header makes the policy
+steps stand in for the phase's default action instead. `(replace)` is only
+meaningful where the boundary has a default action to replace:
+
+| Seam | Fires | Augment (default) | `(replace)` |
+|------|-------|-------------------|-------------|
+| `pre-flight` | start of Phase 1 | run policy steps, then the standard pre-flight checks | policy steps become the pre-flight gate; skip the built-in CI/clean-tree checks |
+| `pre-changelog-style` | before Phase 4 drafts the entry | run policy steps (e.g. enforce a house changelog style), then draft | policy steps produce the entry; skip the default draft heuristic |
+| `pre-apply` | before Phase 5 applies | run policy steps (e.g. edit extra manifests), then bump + commit + tag | policy steps perform the bump/commit/tag; skip the default apply dispatch |
+| `pre-push` | before the `git push` in Phase 6 | run policy steps (a final gate), then push | policy steps perform the push; skip the default `git push` |
+| `post-push` | immediately after the push succeeds | run policy steps | **augment-only** — no default action; a `(replace)` marker is ignored with a warning |
+| `pre-github-release` | before `gh release create` | run policy steps (e.g. wait for publish workflows), then create the Release | policy steps create the Release (or intentionally skip it); skip the default `gh release create` |
+| `post-summary` | after the Phase 7 summary | run policy steps (e.g. deploy a site) | **augment-only** — no default action; a `(replace)` marker is ignored with a warning |
+
+### Unknown seams are surfaced, never silently ignored
+
+Phase 0 enumerates every `## seam: <name>` in the policy file and checks each name
+against the table above. A header naming no known seam — a typo like
+`pre-changelog-styl`, or policy written against a seam this command doesn't expose
+— prints a `WARNING` shown to the operator **before Phase 1 proceeds**, rather
+than binding to nothing. Likewise, `(replace)` on an augment-only seam
+(`post-push`, `post-summary`) warns. This is the guarantee that migrated policy
+cannot silently stop firing.
+
+### Migrating from `/loom:release`
+
+Loom's removed `/loom:release` skill exposed five seams. **All five carry over
+under the same names**, so policy targeting them binds unchanged:
+
+| `/loom:release` seam | `/repo:release` seam | Change |
+|----------------------|----------------------|--------|
+| `pre-changelog-style` | `pre-changelog-style` | none (identity) |
+| `pre-push` | `pre-push` | none (identity) |
+| `post-push` | `post-push` | none (identity) |
+| `pre-github-release` | `pre-github-release` | none (identity) |
+| `post-summary` | `post-summary` | none (identity) |
+
+`/repo:release` adds two boundaries Loom didn't have — `pre-flight` and
+`pre-apply` — for gates that must run before the pre-flight checks or before the
+version bump. To migrate, move the policy text into `.repo/release-policy.md`
+under a `## seam: <name>` header for each old seam name. Nothing is dropped in the
+rename.
+
 ## Principles
 
 Cutting a release is irreversible and outward-facing, so unlike the safe-fix
 hygiene commands it stays **report first, act second** — nothing is committed,
 tagged, or pushed without a yes. **General by design** — the tool and the file
-set are discovered, never assumed. If the repo needs a release-time reminder
+set are discovered, never assumed. If the repo needs a release-time *reminder*
 (e.g. "bump the protocol version when the API changes"), keep it in the repo's
-own CLAUDE.md; this command reads that context at runtime.
+own CLAUDE.md; this command reads that context at runtime. Procedural policy that
+must *run* at a specific point — a gate, an extra manifest edit, a post-release
+deploy — goes in `.repo/release-policy.md` bound to a named seam instead (see
+**Extension points — per-project release policy** above).

--- a/skills/repo/SKILL.md
+++ b/skills/repo/SKILL.md
@@ -28,7 +28,7 @@ costs.
 | [[reset]] | Back to baseline — review stale worktrees/branches/stashes, sync with remote, return to the default branch |
 | [[handoff]] | Roll the session safely — file follow-ups, reset, check for a CLI update, write a handoff note the next session reads first |
 | [[tidy]] | Tidy up — build artifacts, caches, temp files, empty dirs |
-| [[release]] | Cut a release — pre-flight, semver decision, CHANGELOG, version bump, tag, GitHub Release |
+| [[release]] | Cut a release — pre-flight, semver decision, CHANGELOG, version bump, tag, GitHub Release. Supports per-project release policy via named phase-boundary seams in `.repo/release-policy.md` |
 | [[host-optimize]] | Prepare a Mac (or Linux box) for heavy Loom/agent build use — audit Gatekeeper churn, backup-agent interference, build-tree bloat; apply safe fixes, gate consequential ones |
 | [[remote]] | Launch a cloud dev session (GCP or AWS) with this repo ready to go, then open SSH. Its provisioning contract is implemented once in `scripts/repo/repo-remote.sh` (installed to `.claude/skills/repo/scripts/`); the interactive flow delegates to that script, which also serves as a headless `repo-remote up --yes --json` entry point for non-interactive callers (e.g. loom's `fleet add-worker`) |
 | [[update-tools]] | Check installed tool packages (Loom, Anvil, …) against their sources and offer updates |


### PR DESCRIPTION
## Summary

`/repo:release` prescribed Phases 1–7 with no declared points where a project could inject its own procedural steps, so projects migrating off Loom's removed `/loom:release` skill silently lost their release policy — every override named a seam this command didn't expose, and nothing bound, with no error. This adds a documented extension mechanism combining the Curator/Champion-endorsed options 1 + 2: named phase-boundary seams bound to a single per-project policy file, with augment-by-default / replace-by-marker semantics and a mandatory unknown-seam warning.

## Changes

- **`commands/repo/release.md`**
  - New **Phase 0 — Load project release policy**: reads `.repo/release-policy.md`, enumerates every `## seam: <name>` header, and **warns before Phase 1** on any seam that binds to no boundary (typo/orphaned) or a `(replace)` marker on an augment-only seam. The validation is a concrete bash block the executing agent runs, not just prose.
  - New **Extension points** reference section: single policy-file home (`.repo/release-policy.md`, one lookup path by design), file format, a per-seam table stating augment vs `(replace)` semantics, the unknown-seam guarantee, and a `/loom:release` → `/repo:release` migration map.
  - Seam mentions threaded into the Phase 1/4/5/6/7 headers.
  - Principles note updated: advisory *reminders* stay in CLAUDE.md; procedural policy that must *run* goes in the seam file.
- **`skills/repo/SKILL.md`**: one-line update to the `release` row noting per-project policy support (edit confined to that single row to minimize conflict with concurrent #49).
- **`CHANGELOG.md`**: entry under the existing `## Unreleased` section.

### Seam set (superset of the five old `/loom:release` names)

`pre-flight`, `pre-changelog-style`, `pre-apply`, `pre-push`, `post-push`, `pre-github-release`, `post-summary`. All five old Loom names carry over unchanged; `pre-flight` and `pre-apply` are new.

## Acceptance Criteria Verification

- [x] `/repo:release` exposes a documented extension mechanism (named seams + policy file) — not option-3 documentation-of-absence.
- [x] Each seam is named and documented, with augment-vs-replace semantics stated per-seam in the table.
- [x] Migration guidance covers what happens to policy targeting the old `/loom:release` seam names (identity map; nothing dropped).
- [x] A policy override targeting a non-existent seam is **surfaced, not silently ignored** — Phase 0 warns before Phase 1. Verified against a sample policy: unknown `pre-changelog-styl` and `(replace)` on augment-only `post-push` both warn; valid seams bind; a non-seam `## Notes` header is ignored.

## Test Plan

- [x] `pnpm test` — **782 pass / 0 fail** (unchanged from baseline; prose-skill change, no test-harness coverage for command semantics).
- [x] Seam-validation bash logic exercised against a sample `release-policy.md` covering augment, replace, augment-only-replace-warning, unknown-seam-warning, and ignored-non-seam-header cases — all correct.

## Notes

- Out of scope (per issue scope guard): retrofitting extension points into other `/repo:*` commands.
- Unrelated observation (left alone, per the task brief): `/repo:release` Phase 4/5 does not fold an existing `## Unreleased` CHANGELOG section into the new version heading. The issue's acceptance criteria do not cover this, so it is intentionally not addressed here.

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)