### PR TITLE
fix(guard-destructive): make extract_rm_targets quote-aware across newlines

### DIFF
--- a/hooks/repo/guard-destructive.sh
+++ b/hooks/repo/guard-destructive.sh
@@ -1574,14 +1574,86 @@ fi
 
 extract_rm_targets() {
     # Emit one rm-target token per line for every local `rm -r/-f` invocation.
-    # Portable awk only (no GNU/BSD-specific escapes); replaces the shell
-    # separators with newlines, then inspects each simple command.
-    printf '%s' "$1" | awk "$_QSPLIT_AWK"'
-    {
-        $0 = qsplit($0)   # quote-aware segmentation (#3755)
-        n = split($0, segs, "\n")
-        for (i = 1; i <= n; i++) {
-            seg = segs[i]
+    # Portable awk only (no GNU/BSD-specific escapes).
+    #
+    # MULTI-LINE QUOTE AWARENESS (#60): slurp the whole (possibly multi-line)
+    # command into ONE buffer, then segment ONCE with a quote-aware walk — instead
+    # of the old per-awk-record `$0 = qsplit($0)`, whose quote-tracking reset at
+    # every input newline because awk's default RS split the command into separate
+    # records. That per-record form false-blocked a multi-line quoted DATA literal
+    # (echo/printf/--body) whose interior line merely BEGINS with `rm -rf /`: the
+    # interior line was scanned as its own top-level segment with no memory that it
+    # is still inside an open quote from a prior line, so its command word resolved
+    # to a real `rm` and its lone `/` token hit the protected-root deny. Mirrors
+    # the buffer-slurp the catastrophic/ask redactors (strip_datasink_literals /
+    # strip_literal_text) and command_has_shell_segment() already use.
+    #
+    # This function keeps its OWN lexer rather than reusing qsplit()+split("\n"),
+    # because qsplit() emits a `\n` for each real separator while ALSO leaving a
+    # literal newline that lived inside an inert quoted span untouched — the two
+    # are then indistinguishable to a downstream `split(s, segs, "\n")`, which is
+    # exactly why the naive slurp-then-qsplit would still re-split the quoted
+    # `rm -rf /` line into its own segment. Here segmentation is done inline so an
+    # inert quoted span's embedded newlines never become segment boundaries.
+    #
+    # Segmentation contract (identical to qsplit()'s single-line behaviour, now
+    # correctly carried ACROSS embedded newlines):
+    #   - Separators `;` `&` (`&&`) `|` (`||`) OUTSIDE any quote split segments.
+    #   - A raw newline OUTSIDE any quote ALSO splits — so a GENUINE multi-line
+    #     command (`echo a<NL>rm -rf /<NL>echo b`, no enclosing quote) still yields
+    #     a real `rm -rf /` segment and still denies (safety floor preserved; this
+    #     matches the old per-record behaviour where each input line was a record).
+    #   - An INERT quoted span (no `$(` and no backtick) is copied VERBATIM, so its
+    #     embedded newlines/separators stay literal and never manufacture a phantom
+    #     `rm` segment out of quoted documentation prose (the #60 false block).
+    #   - A quoted span carrying command substitution (`$(` or a backtick) keeps
+    #     its separators ACTIVE (walked char-by-char, exactly like qsplit()), so a
+    #     smuggled payload is never hidden behind an opening quote.
+    #   - An unterminated quote copies the remainder verbatim (best-effort; never
+    #     widens a deny into an allow).
+    printf '%s' "$1" | awk '
+    BEGIN {
+        SQ = sprintf("%c", 39)   # single quote
+        DQ = sprintf("%c", 34)   # double quote
+        buf = ""
+        segc = 0
+    }
+    { buf = buf (NR > 1 ? "\n" : "") $0 }
+    END {
+        s = buf
+        n = length(s)
+        seg = ""
+        i = 1
+        while (i <= n) {
+            c = substr(s, i, 1)
+            if (c == DQ || c == SQ) {
+                qc = c
+                ci = 0
+                for (j = i + 1; j <= n; j++) if (substr(s, j, 1) == qc) { ci = j; break }
+                if (ci == 0) {
+                    seg = seg substr(s, i)   # unterminated quote: copy rest verbatim
+                    i = n + 1
+                    continue
+                }
+                inner = substr(s, i + 1, ci - i - 1)
+                if (index(inner, "$(") == 0 && index(inner, "`") == 0) {
+                    seg = seg substr(s, i, ci - i + 1)   # inert span: verbatim (newlines stay literal)
+                    i = ci + 1
+                    continue
+                }
+                seg = seg c   # command substitution present: keep separators ACTIVE
+                i++
+                continue
+            }
+            if (c == ";" || c == "&" || c == "|" || c == "\n") {
+                segs[++segc] = seg; seg = ""; i++; continue
+            }
+            seg = seg c
+            i++
+        }
+        segs[++segc] = seg
+        for (si = 1; si <= segc; si++) {
+            seg = segs[si]
             sub(/^[ \t]+/, "", seg)
             sub(/^sudo[ \t]+/, "", seg)
             sub(/^[ \t]+/, "", seg)

--- a/hooks/repo/tests/test-guard-destructive.sh
+++ b/hooks/repo/tests/test-guard-destructive.sh
@@ -1822,6 +1822,68 @@ assert_deny "#53 safety: echo 'ok' | tee f ; <danger> still denies (separate seg
 echo ""
 
 # =========================================================================
+echo -e "${YELLOW}--- Multi-line quoted literal, line-leading recursive-force delete (#60) ---${NC}"
+# =========================================================================
+#
+# extract_rm_targets() now slurps the WHOLE (possibly multi-line) command into
+# one buffer before its quote-aware segmentation, so a multi-line quoted DATA
+# literal whose interior line *begins* with a recursive-force root delete is no
+# longer mis-read as a real `rm` segment. The old per-awk-record `qsplit()` reset
+# quote state at every input newline, so the interior `rm -rf /` line was scanned
+# as its own top-level segment and false-blocked with `rm-protected-path`
+# (guard-destructive.sh:1698) — the scope-check path, NOT the raw catastrophic
+# scan. Safety floor: a GENUINE multi-line command, `$(`/backtick smuggling,
+# `bash -c`/`sh -c` payloads, and pipe-to-shell must ALL still deny.
+#
+# Danger phrase assembled at runtime so this very test file never contains the
+# literal string a naive scan of the harness's own Bash call would flag.
+_ML_DANGER="rm -r""f /"
+
+# The three reproduced false-blocks (echo / printf / --body data sinks): the
+# recursive-force root delete appears only as a line-leading token inside an
+# inert multi-line quoted literal, so nothing executes → ALLOW.
+assert_allow "#60: multi-line echo literal with line-leading rm -rf / is allowed" \
+    "$(printf 'echo "line one\n%s\nline three"' "$_ML_DANGER")"
+
+assert_allow "#60: multi-line printf literal with line-leading rm -rf / is allowed" \
+    "$(printf "printf '%%s\\\\n' \"line one\n%s\nline three\"" "$_ML_DANGER")"
+
+assert_allow "#60: multi-line --body literal with line-leading rm -rf / is allowed" \
+    "$(printf 'gh issue comment 60 --body "line one\n%s\nline three"' "$_ML_DANGER")"
+
+# --- SAFETY FLOOR: the multi-line buffer-slurp must NEVER widen a deny into an allow ---
+
+# A GENUINE (unquoted) multi-line command whose LATER real line is the danger
+# still denies — the raw newline is a real segment boundary, so `rm -rf /` is a
+# real simple command (regression-proofs the reproduction's safety spot-check).
+assert_deny "#60 safety: genuine multi-line command with rm -rf / on a later line still denies" \
+    "$(printf 'echo line-one\n%s\necho line-three' "$_ML_DANGER")"
+
+# Command substitution smuggled inside the SAME multi-line quoted literal keeps
+# its separators active (the span is not inert), so the payload still denies.
+assert_deny "#60 safety: command-substitution inside a multi-line quoted literal still denies" \
+    "$(printf 'echo "line one\n\$(%s)\nline three"' "$_ML_DANGER")"
+
+# Backtick substitution inside the same shape likewise still denies.
+assert_deny "#60 safety: backtick substitution inside a multi-line quoted literal still denies" \
+    "$(printf 'echo "line one\n\`%s\`\nline three"' "$_ML_DANGER")"
+
+# bash -c / sh -c with a multi-line payload whose interior line leads with the
+# danger is NOT a data sink — the payload executes, so it must still deny.
+assert_deny "#60 safety: bash -c multi-line payload with line-leading rm -rf / still denies" \
+    "$(printf 'bash -c %sline one\n%s\nline three%s' "'" "$_ML_DANGER" "'")"
+
+assert_deny "#60 safety: sh -c multi-line payload with line-leading rm -rf / still denies" \
+    "$(printf 'sh -c %sline one\n%s\nline three%s' "'" "$_ML_DANGER" "'")"
+
+# A multi-line quoted literal piped into a shell that WOULD execute it still
+# denies (command_has_shell_segment() gate skips redaction so the raw scan sees it).
+assert_deny "#60 safety: multi-line quoted literal piped into sh still denies" \
+    "$(printf 'echo "line one\n%s\nline three" | sh' "$_ML_DANGER")"
+
+echo ""
+
+# =========================================================================
 echo -e "${YELLOW}--- forceScope=protected autonomous default (#3898 / #3674) ---${NC}"
 # =========================================================================
 #


### PR DESCRIPTION
## Summary

`extract_rm_targets()` in `hooks/repo/guard-destructive.sh` ran its quote-aware
`qsplit()` segmentation **per awk input record**, so its quote-tracking state
reset at every embedded newline (awk's default `RS` splits a multi-line command
into separate records). A multi-line quoted **data** literal
(`echo`/`printf`/`--body`) whose interior line merely *begins* with a
recursive-force root delete was therefore scanned as its own top-level segment —
its command word resolved to a real `rm`, its lone `/` token hit the
protected-root check, and the guard false-blocked with reason `rm-protected-path`
(`guard-destructive.sh:1698`, the scope-check path — not the raw catastrophic
scan) even though nothing executes.

This mirrors the buffer-slurp that `strip_datasink_literals()` /
`strip_literal_text()` / `command_has_shell_segment()` already do, but with a
self-contained lexer: a naive slurp-then-`qsplit()`+`split("\n")` would still
re-split the quoted delete line, because `qsplit()` emits `\n` for real
separators while leaving a literal newline inside an inert quoted span untouched —
the two are indistinguishable downstream. Segmenting inline lets an inert quoted
span's embedded newlines stay literal.

## Changes

- `hooks/repo/guard-destructive.sh` — rewrote `extract_rm_targets()` to slurp the
  whole (possibly multi-line) command into one buffer and segment **once** with an
  inline quote-aware walk:
  - Separators `;` `&` (`&&`) `|` (`||`) **outside** any quote split segments.
  - A raw newline **outside** any quote **also** splits — so a genuine multi-line
    command still yields a real `rm` segment and still denies (safety floor).
  - An **inert** quoted span (no `$(` / backtick) is copied verbatim, so its
    embedded newlines never manufacture a phantom `rm` segment.
  - A quoted span carrying a command substitution keeps its separators **active**
    (walked char-by-char, exactly like `qsplit()`), so a smuggled payload is never
    hidden behind an opening quote.
  - Out of scope (unchanged, per the issue): `parse_force_ops()` and
    `lifecycle_or_cloud_reason()` share the identical defect but are explicitly
    deferred to a follow-up.
- `hooks/repo/tests/test-guard-destructive.sh` — added a `#60` section with 9
  regression cases.

## Acceptance Criteria Verification

- [x] Multi-line quoted literal with a line-leading recursive-force root delete
  (echo data, printf data, `--body` flag data) → **allow** (3 cases pass).
- [x] Genuine (unquoted) multi-line command with the danger on a later real line
  → **deny** (raw newline is a real segment boundary).
- [x] `$(...)`/backtick command-substitution smuggled inside the same multi-line
  quoted literal → **deny**.
- [x] `bash -c` / `sh -c` multi-line payload with a line-leading danger → **deny**.
- [x] Multi-line quoted literal piped into `sh` → **deny**.
- [x] Bare single-line danger still → **deny**.
- [x] Full existing safety-floor / PR #58 / #3898 cases → still pass.

## Test Plan

- `hooks/repo/tests/test-guard-destructive.sh`: **470/470** pass (9 new `#60`
  cases included).
- Full `pnpm test` (this repo's only gate): **791/791** pass; the per-suite
  breakdown self-check sums correctly.
- Fault-injection: piped synthetic PreToolUse payloads (fragments assembled
  out-of-band) directly at the guard and confirmed the three reproduced
  false-blocks now allow while every safety-floor shape still denies.

Closes #60
