### PR TITLE
docs(ci): record decision to not require the test status check on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,23 @@ name: CI
 # well within a single job's budget, so there is no reason to split coverage and
 # risk it looking like it covers more than it does.
 #
-# Note: this workflow does NOT enable required-status-check branch protection.
-# Requiring this check to merge is a separate, deliberate decision (see #48's
-# acceptance criteria) and must not be silently enabled here.
+# Required-status-check branch protection is deliberately NOT enabled for this
+# check. Issue #73 evaluated requiring the `pnpm test (guard/handoff/loss-check
+# suite)` context on `main` and the operator decided (2026-07-29) NOT to require
+# it: this is a solo-operator repo with agent-driven merges where merge-pr.sh
+# already waits for configured checks and treats a red check as a stop signal,
+# so the throughput cost of a hard gate (an added CI wait plus forced sibling-PR
+# branch updates on every sweep-wave merge) is not worth it yet. Revisit if
+# collaborators join.
+#
+# LOAD-BEARING for any future enabler: if protection is ever enabled, it MUST be
+# CLASSIC branch protection (PUT /repos/{owner}/{repo}/branches/main/protection),
+# NOT a Repository Ruleset. merge-pr.sh's required-check detection
+# (forge_get_required_status_check_contexts) reads GraphQL
+# repository.ref.branchProtectionRule.requiredStatusCheckContexts, which only
+# classic protection populates. A ruleset leaves branchProtectionRule null, so
+# the detection returns empty, merge-pr.sh's no-required-checks fallback fires,
+# and the protection is silently bypassed by an immediate synchronous merge.
 
 on:
   pull_request:


### PR DESCRIPTION
## Summary

Records the operator's decision for issue #73: **do not require** the `pnpm test (guard/handoff/loss-check suite)` status check on `main`. This is a documentation-only change to the `.github/workflows/ci.yml` header comment — no branch-protection or ruleset API was touched, and none was enabled.

The prior header described the requirement decision as pending/deferred ("does NOT enable required-status-check protection... a separate, deliberate decision (see #48's acceptance criteria)"). It now states the resolved outcome and references #73.

## Changes

- `.github/workflows/ci.yml`: replace the pending-decision note with:
  - The recorded operator decision (2026-07-29): the check is deliberately not required. Rationale — solo-operator repo with agent-driven merges where `merge-pr.sh` already waits for configured checks and treats a red check as a stop signal, so the throughput cost of a hard gate (added CI wait plus forced sibling-PR branch updates on every sweep-wave merge) is not worth it yet; revisit if collaborators join.
  - A load-bearing note for any future enabler: IF protection is ever enabled it MUST be **classic branch protection** (`PUT /branches/main/protection`), NOT a Repository Ruleset — `merge-pr.sh`'s `forge_get_required_status_check_contexts` reads the GraphQL `branchProtectionRule.requiredStatusCheckContexts` field, which rulesets do not populate, so a ruleset would leave the detection empty, fire the no-required-checks fallback, and be silently bypassed by an immediate synchronous merge.

## Acceptance Criteria Verification

This PR implements **Branch B (document why not)** from the curator enhancement, per the operator's recorded decision.

- [x] Decide: document why not — recorded in the workflow header comment.
- [x] Record the decision in the workflow header comment — done, references #73 and states the resolved outcome rather than a pending/deferred decision.
- [x] Branch B — no regression: no API changes made; `branches/main/protection` remains absent and `rules/branches/main` remains empty (nothing was enabled while documenting why not).
- [x] Either branch: the header comment no longer describes the decision as pending/deferred.

## Test Plan

- `pnpm test` from the worktree: **PASS 791 / FAIL 0** (guard-destructive 470, session-start-handoff 99, install-claude-md-markers 59, branches-loss-check 37, repo-remote 71, run.sh inline smoke 55).
- Change is a comment-only edit to a workflow file; no code paths altered.

Closes #73
