### PR TITLE
fix(guard-destructive): share ml_segment() lexer so force-op/lifecycle parsers are multi-line quote-aware

### DIFF
--- a/hooks/repo/guard-destructive.sh
+++ b/hooks/repo/guard-destructive.sh
@@ -924,6 +924,90 @@ function qsplit(s,   out, n, i, c, j, qc, ci, inner, SQ, DQ) {
 }
 '
 
+# =============================================================================
+# MULTI-LINE QUOTE-AWARE SEGMENTATION (#71)
+#
+# The three segment parsers (parse_force_ops, lifecycle_or_cloud_reason,
+# extract_rm_targets) originally segmented per awk INPUT RECORD with
+# `$0 = qsplit($0); split($0, segs, "\n")`. Because awk's default RS="\n" splits
+# a multi-line command into separate records BEFORE the pattern block runs,
+# qsplit()'s quote-tracking state — scoped to a single call — reset at every
+# embedded newline. An interior line of an otherwise-inert multi-line quoted
+# DATA literal (echo/printf/--body) was therefore lexed as its own top-level
+# segment with no memory that it is still inside an open quote from a prior line,
+# so a quoted `git push --force origin main` false-`ask`ed (parse_force_ops) and
+# a quoted `halt` false-`deny`ed (lifecycle_or_cloud_reason). PR #69 fixed the
+# identical defect in extract_rm_targets() with a whole-buffer slurp-then-segment
+# lexer; this shared helper generalizes that lexer so all three parsers segment
+# ONCE over the full command and cannot drift (the same rationale the _QSPLIT_AWK
+# header gives for sharing qsplit()).
+#
+# `ml_segment(buf, segs)` fills the caller's `segs[]` out-array (AWK passes arrays
+# by reference) with one entry per top-level segment and returns the count. It
+# deliberately does NOT reuse qsplit()+split("\n"): qsplit() emits a `\n` for each
+# REAL separator while ALSO leaving a literal newline that lived inside an inert
+# quoted span untouched, so the two become indistinguishable to a downstream
+# `split(s, segs, "\n")`. Segmentation is therefore done inline here, so an inert
+# quoted span's embedded newlines never become segment boundaries.
+#
+# Segmentation contract (identical to qsplit()'s single-line behaviour, now
+# correctly carried ACROSS embedded newlines):
+#   - Separators `;` `&` (`&&`) `|` (`||`) OUTSIDE any quote split segments.
+#   - A raw newline OUTSIDE any quote ALSO splits — so a GENUINE multi-line
+#     command still yields a real later-line segment and still denies (safety
+#     floor preserved; matches the old per-record behaviour where each input line
+#     was its own record).
+#   - An INERT quoted span (no `$(` and no backtick) is copied VERBATIM, so its
+#     embedded newlines/separators stay literal and never manufacture a phantom
+#     segment out of quoted documentation prose (the false positive).
+#   - A quoted span carrying command substitution (`$(` or a backtick) keeps its
+#     separators ACTIVE (walked char-by-char, exactly like qsplit()), so a
+#     smuggled payload is never hidden behind an opening quote.
+#   - An unterminated quote copies the remainder verbatim (best-effort; never
+#     widens a deny into an allow).
+# =============================================================================
+_ML_QSPLIT_AWK='
+function ml_segment(buf, segs,   SQ, DQ, s, n, seg, segc, i, c, qc, ci, j, inner) {
+    SQ = sprintf("%c", 39)   # single quote
+    DQ = sprintf("%c", 34)   # double quote
+    split("", segs)          # clear the caller-supplied out-array
+    s = buf
+    n = length(s)
+    seg = ""
+    segc = 0
+    i = 1
+    while (i <= n) {
+        c = substr(s, i, 1)
+        if (c == DQ || c == SQ) {
+            qc = c
+            ci = 0
+            for (j = i + 1; j <= n; j++) if (substr(s, j, 1) == qc) { ci = j; break }
+            if (ci == 0) {
+                seg = seg substr(s, i)   # unterminated quote: copy rest verbatim
+                i = n + 1
+                continue
+            }
+            inner = substr(s, i + 1, ci - i - 1)
+            if (index(inner, "$(") == 0 && index(inner, "`") == 0) {
+                seg = seg substr(s, i, ci - i + 1)   # inert span: verbatim (newlines stay literal)
+                i = ci + 1
+                continue
+            }
+            seg = seg c   # command substitution present: keep separators ACTIVE
+            i++
+            continue
+        }
+        if (c == ";" || c == "&" || c == "|" || c == "\n") {
+            segs[++segc] = seg; seg = ""; i++; continue
+        }
+        seg = seg c
+        i++
+    }
+    segs[++segc] = seg
+    return segc
+}
+'
+
 # Parse force-op segments out of a command, emitting one TAB-separated
 # "<cpath>\t<target>" line per genuine git force-push / hard-reset. Portable awk
 # only (mirrors extract_rm_targets / lifecycle_or_cloud_reason segment parsing):
@@ -943,12 +1027,20 @@ function qsplit(s,   out, n, i, c, j, qc, ci, inner, SQ, DQ) {
 #   - reset --hard: always emitted with <target> = "@HEAD@".
 # The caller resolves "@HEAD@" to the checked-out branch and applies the mode.
 parse_force_ops() {
-    printf '%s' "$1" | awk "$_QSPLIT_AWK"'
-    BEGIN { SEP = sprintf("%c", 31) }  # US (unit separator) — non-whitespace so
-                                       # bash read does not trim an empty cpath.
-    {
-        $0 = qsplit($0)   # quote-aware segmentation (#3755)
-        n = split($0, segs, "\n")
+    printf '%s' "$1" | awk "$_ML_QSPLIT_AWK"'
+    BEGIN {
+        SEP = sprintf("%c", 31)  # US (unit separator) — non-whitespace so bash
+                                 # read does not trim an empty cpath.
+        buf = ""
+    }
+    # Slurp the whole (possibly multi-line) command, then segment ONCE with the
+    # shared quote-aware lexer (#71) so a multi-line quoted DATA literal whose
+    # interior line is a force-push phrase is no longer mis-read as a real
+    # segment (the pre-#71 per-record `qsplit()` reset quote state at each
+    # embedded newline).
+    { buf = buf (NR > 1 ? "\n" : "") $0 }
+    END {
+        n = ml_segment(buf, segs)
         for (i = 1; i <= n; i++) {
             seg = segs[i]
             sub(/^[ \t]+/, "", seg)
@@ -1470,10 +1562,16 @@ fi
 lifecycle_or_cloud_reason() {
     # Emit a deny reason (one per line) for every segment whose command word is a
     # system-lifecycle command or an az/gcloud delete. Portable awk only.
-    printf '%s' "$1" | awk "$_QSPLIT_AWK"'
-    {
-        $0 = qsplit($0)   # quote-aware segmentation (#3755)
-        n = split($0, segs, "\n")
+    printf '%s' "$1" | awk "$_ML_QSPLIT_AWK"'
+    BEGIN { buf = "" }
+    # Slurp the whole (possibly multi-line) command, then segment ONCE with the
+    # shared quote-aware lexer (#71) so a multi-line quoted DATA literal whose
+    # interior line is a lifecycle/cloud word (e.g. `halt`) is no longer mis-read
+    # as a real segment (the pre-#71 per-record `qsplit()` reset quote state at
+    # each embedded newline, hard-denying inert quoted prose).
+    { buf = buf (NR > 1 ? "\n" : "") $0 }
+    END {
+        n = ml_segment(buf, segs)
         for (i = 1; i <= n; i++) {
             seg = segs[i]
             sub(/^[ \t]+/, "", seg)
@@ -1588,70 +1686,23 @@ extract_rm_targets() {
     # the buffer-slurp the catastrophic/ask redactors (strip_datasink_literals /
     # strip_literal_text) and command_has_shell_segment() already use.
     #
-    # This function keeps its OWN lexer rather than reusing qsplit()+split("\n"),
-    # because qsplit() emits a `\n` for each real separator while ALSO leaving a
-    # literal newline that lived inside an inert quoted span untouched — the two
-    # are then indistinguishable to a downstream `split(s, segs, "\n")`, which is
-    # exactly why the naive slurp-then-qsplit would still re-split the quoted
-    # `rm -rf /` line into its own segment. Here segmentation is done inline so an
-    # inert quoted span's embedded newlines never become segment boundaries.
-    #
-    # Segmentation contract (identical to qsplit()'s single-line behaviour, now
-    # correctly carried ACROSS embedded newlines):
-    #   - Separators `;` `&` (`&&`) `|` (`||`) OUTSIDE any quote split segments.
-    #   - A raw newline OUTSIDE any quote ALSO splits — so a GENUINE multi-line
-    #     command (`echo a<NL>rm -rf /<NL>echo b`, no enclosing quote) still yields
-    #     a real `rm -rf /` segment and still denies (safety floor preserved; this
-    #     matches the old per-record behaviour where each input line was a record).
-    #   - An INERT quoted span (no `$(` and no backtick) is copied VERBATIM, so its
-    #     embedded newlines/separators stay literal and never manufacture a phantom
-    #     `rm` segment out of quoted documentation prose (the #60 false block).
-    #   - A quoted span carrying command substitution (`$(` or a backtick) keeps
-    #     its separators ACTIVE (walked char-by-char, exactly like qsplit()), so a
-    #     smuggled payload is never hidden behind an opening quote.
-    #   - An unterminated quote copies the remainder verbatim (best-effort; never
-    #     widens a deny into an allow).
-    printf '%s' "$1" | awk '
-    BEGIN {
-        SQ = sprintf("%c", 39)   # single quote
-        DQ = sprintf("%c", 34)   # double quote
-        buf = ""
-        segc = 0
-    }
+    # Segmentation is delegated to the shared ml_segment() lexer (#71,
+    # _ML_QSPLIT_AWK) rather than reusing qsplit()+split("\n"), because qsplit()
+    # emits a `\n` for each real separator while ALSO leaving a literal newline
+    # that lived inside an inert quoted span untouched — the two are then
+    # indistinguishable to a downstream `split(s, segs, "\n")`, which is exactly
+    # why the naive slurp-then-qsplit would still re-split the quoted `rm -rf /`
+    # line into its own segment. ml_segment() walks the buffer once so an inert
+    # quoted span's embedded newlines never become segment boundaries. PR #69
+    # introduced this lexer inline here; #71 extracted it into the shared helper
+    # so parse_force_ops()/lifecycle_or_cloud_reason() reuse the SAME algorithm
+    # instead of duplicating it (see the _ML_QSPLIT_AWK header for the full
+    # segmentation contract).
+    printf '%s' "$1" | awk "$_ML_QSPLIT_AWK"'
+    BEGIN { buf = "" }
     { buf = buf (NR > 1 ? "\n" : "") $0 }
     END {
-        s = buf
-        n = length(s)
-        seg = ""
-        i = 1
-        while (i <= n) {
-            c = substr(s, i, 1)
-            if (c == DQ || c == SQ) {
-                qc = c
-                ci = 0
-                for (j = i + 1; j <= n; j++) if (substr(s, j, 1) == qc) { ci = j; break }
-                if (ci == 0) {
-                    seg = seg substr(s, i)   # unterminated quote: copy rest verbatim
-                    i = n + 1
-                    continue
-                }
-                inner = substr(s, i + 1, ci - i - 1)
-                if (index(inner, "$(") == 0 && index(inner, "`") == 0) {
-                    seg = seg substr(s, i, ci - i + 1)   # inert span: verbatim (newlines stay literal)
-                    i = ci + 1
-                    continue
-                }
-                seg = seg c   # command substitution present: keep separators ACTIVE
-                i++
-                continue
-            }
-            if (c == ";" || c == "&" || c == "|" || c == "\n") {
-                segs[++segc] = seg; seg = ""; i++; continue
-            }
-            seg = seg c
-            i++
-        }
-        segs[++segc] = seg
+        segc = ml_segment(buf, segs)
         for (si = 1; si <= segc; si++) {
             seg = segs[si]
             sub(/^[ \t]+/, "", seg)

--- a/hooks/repo/tests/test-guard-destructive.sh
+++ b/hooks/repo/tests/test-guard-destructive.sh
@@ -1884,6 +1884,106 @@ assert_deny "#60 safety: multi-line quoted literal piped into sh still denies" \
 echo ""
 
 # =========================================================================
+echo -e "${YELLOW}--- Multi-line quoted literal, line-leading force-push / lifecycle (#71) ---${NC}"
+# =========================================================================
+#
+# parse_force_ops() and lifecycle_or_cloud_reason() shared the exact per-record
+# qsplit defect PR #69 fixed in extract_rm_targets(): they segmented per awk INPUT
+# RECORD, so quote-tracking state reset at every embedded newline and an interior
+# line of an otherwise-inert multi-line quoted DATA literal was lexed as its own
+# top-level segment. A quoted force-push-to-main phrase therefore false-`ask`ed
+# (parse_force_ops) and a quoted `halt`/`reboot`/cloud-delete false-`deny`ed
+# (lifecycle_or_cloud_reason). #71 routes all three parsers through the shared
+# ml_segment() buffer-slurp lexer (_ML_QSPLIT_AWK), so they segment ONCE over the
+# whole command. Safety floor: a GENUINE multi-line command, `$(`/backtick
+# smuggling, `bash -c`/`sh -c` payloads, and pipe-to-shell must ALL still deny.
+#
+# Danger phrases assembled at runtime so this test file never contains the literal
+# string a naive scan of the harness's own Bash call would flag (mirrors #60).
+_ML71_FORCE="git push --for""ce origin main"
+_ML71_HALT="ha""lt"
+_ML71_REBOOT="rebo""ot"
+_ML71_POWEROFF="powero""ff"
+_ML71_SHUTDOWN="shutdo""wn"
+_ML71_AZ="az group de""lete"
+_ML71_GCLOUD="gcloud compute instances de""lete"
+
+# --- parse_force_ops(): multi-line quoted force-push data literal → ALLOW ---
+# (currently false-`ask`s: the interior line was scanned as its own git segment).
+assert_allow "#71: multi-line echo literal with interior force-push-to-main is allowed" \
+    "$(printf 'echo "line one\n%s\nline three"' "$_ML71_FORCE")"
+
+assert_allow "#71: multi-line printf literal with interior force-push-to-main is allowed" \
+    "$(printf "printf '%%s\\\\n' \"line one\n%s\nline three\"" "$_ML71_FORCE")"
+
+assert_allow "#71: multi-line --body literal with interior force-push-to-main is allowed" \
+    "$(printf 'gh issue comment 71 --body "line one\n%s\nline three"' "$_ML71_FORCE")"
+
+# --- lifecycle_or_cloud_reason(): multi-line quoted lifecycle/cloud literal → ALLOW ---
+# (currently false-hard-`deny`s: same severity class as the #60 extract_rm_targets bug).
+assert_allow "#71: multi-line echo literal with interior halt is allowed" \
+    "$(printf 'echo "line one\n%s\nline three"' "$_ML71_HALT")"
+
+assert_allow "#71: multi-line echo literal with interior reboot is allowed" \
+    "$(printf 'echo "line one\n%s\nline three"' "$_ML71_REBOOT")"
+
+assert_allow "#71: multi-line echo literal with interior poweroff is allowed" \
+    "$(printf 'echo "line one\n%s\nline three"' "$_ML71_POWEROFF")"
+
+assert_allow "#71: multi-line echo literal with interior shutdown is allowed" \
+    "$(printf 'echo "line one\n%s\nline three"' "$_ML71_SHUTDOWN")"
+
+assert_allow "#71: multi-line --body literal with interior halt is allowed" \
+    "$(printf 'gh issue comment 71 --body "line one\n%s\nline three"' "$_ML71_HALT")"
+
+assert_allow "#71: multi-line echo literal with interior az ... delete is allowed" \
+    "$(printf 'echo "line one\n%s\nline three"' "$_ML71_AZ")"
+
+assert_allow "#71: multi-line echo literal with interior gcloud ... delete is allowed" \
+    "$(printf 'echo "line one\n%s\nline three"' "$_ML71_GCLOUD")"
+
+# --- SAFETY FLOOR: the multi-line buffer-slurp must NEVER widen a deny into an allow ---
+
+# GENUINE (unquoted) multi-line command whose LATER real line is the danger still
+# denies — the raw newline is a real segment boundary, so the danger is a real
+# simple command. Tested directly against BOTH functions' own behaviour.
+assert_deny "#71 safety: genuine multi-line command with force-push-to-main on a later line still denies" \
+    "$(printf 'echo line-one\n%s\necho line-three' "$_ML71_FORCE")"
+
+assert_deny "#71 safety: genuine multi-line command with halt on a later line still denies" \
+    "$(printf 'echo line-one\n%s\necho line-three' "$_ML71_HALT")"
+
+assert_deny "#71 safety: genuine multi-line command with az ... delete on a later line still denies" \
+    "$(printf 'echo line-one\n%s\necho line-three' "$_ML71_AZ")"
+
+# Command substitution / backtick smuggled inside the SAME multi-line quoted
+# literal keeps its separators active (the span is not inert), so it still denies.
+assert_deny "#71 safety: command-substitution force-push inside a multi-line quoted literal still denies" \
+    "$(printf 'echo "line one\n\$(%s)\nline three"' "$_ML71_FORCE")"
+
+assert_deny "#71 safety: backtick force-push inside a multi-line quoted literal still denies" \
+    "$(printf 'echo "line one\n\`%s\`\nline three"' "$_ML71_FORCE")"
+
+# bash -c / sh -c with a multi-line payload whose interior line leads with the
+# danger is NOT a data sink — the payload executes, so it must still deny. (The
+# force-push-to-main phrase is a raw catastrophic pattern, so this holds; note
+# lifecycle words like `halt` inside an inert `-c`/pipe quote are a SEPARATE
+# pre-existing limitation independent of this multi-line fix — `sh -c 'halt'`
+# allows on origin/main too — so those shapes are intentionally not asserted here.)
+assert_deny "#71 safety: bash -c multi-line payload with line-leading force-push still denies" \
+    "$(printf 'bash -c %sline one\n%s\nline three%s' "'" "$_ML71_FORCE" "'")"
+
+assert_deny "#71 safety: sh -c multi-line payload with line-leading force-push still denies" \
+    "$(printf 'sh -c %sline one\n%s\nline three%s' "'" "$_ML71_FORCE" "'")"
+
+# A multi-line quoted literal piped into a shell that WOULD execute it still denies
+# (command_has_shell_segment() gate skips redaction so the raw scan sees it).
+assert_deny "#71 safety: multi-line quoted force-push literal piped into sh still denies" \
+    "$(printf 'echo "line one\n%s\nline three" | sh' "$_ML71_FORCE")"
+
+echo ""
+
+# =========================================================================
 echo -e "${YELLOW}--- forceScope=protected autonomous default (#3898 / #3674) ---${NC}"
 # =========================================================================
 #


### PR DESCRIPTION
## Summary

`parse_force_ops()` and `lifecycle_or_cloud_reason()` shared the exact per-record `qsplit` multi-line defect PR #69 fixed only in `extract_rm_targets()`. Both segmented per awk **input record** (`$0 = qsplit($0); split($0, segs, "\n")`), so quote-tracking state reset at every embedded newline. An interior line of an inert multi-line quoted DATA literal (`echo`/`printf`/`--body`) was lexed as its own top-level segment: a quoted force-push-to-main phrase false-`ask`ed (parse_force_ops), and a quoted `halt`/`reboot`/`poweroff`/`shutdown`/`az|gcloud delete` false-hard-`deny`ed (lifecycle_or_cloud_reason — same UX severity as the #60 bug).

Following the Curator's recommendation, PR #69's inline buffer-slurp lexer is extracted into a shared `ml_segment(buf, segs)` awk helper (`_ML_QSPLIT_AWK`, placed beside `_QSPLIT_AWK`; fills the caller's array by reference, mirroring `qsplit()`'s sharing pattern) rather than duplicating the ~40-line walk. All three parsers now route through it and segment **once** over the whole command, so they cannot drift.

The optional stretch goal was taken: `extract_rm_targets()` now calls the shared helper instead of its private inline copy, leaving exactly **one** canonical segmentation walk (all pre-existing #60 tests stay green).

### Blast-radius note (from the issue)
`lifecycle_or_cloud_reason()`'s false positive was a hard **deny**; `parse_force_ops()`'s was only an **ask** in the default `guards.forceScope:"all"` mode (degrading to protected-target-only in `"protected"`, unreachable in `"off"`).

## Changes

- `hooks/repo/guard-destructive.sh`
  - New `_ML_QSPLIT_AWK` shared awk source with `ml_segment(buf, segs)` (extracted from `extract_rm_targets()`'s inline walk, generalized to take `buf` as a param and fill `segs[]` as an out-array; returns the segment count).
  - `parse_force_ops()` and `lifecycle_or_cloud_reason()`: replaced the per-record `qsplit()`/`split("\n")` pattern block with a `BEGIN{buf=""} {buf=...} END{ n=ml_segment(buf,segs); ... }` buffer-slurp. Per-segment token logic unchanged.
  - `extract_rm_targets()`: refactored to call the shared `ml_segment()` (stretch goal); comment updated to reflect the now-shared lexer.
- `hooks/repo/tests/test-guard-destructive.sh`
  - New `#71` regression section (mirrors the `#60` template; danger phrases assembled at runtime so the test file stays un-flaggable).

## Acceptance Criteria Verification

- [x] Port PR #69's whole-buffer lexing to both functions (via a shared helper) — done; `ml_segment()` shared across all three parsers.
- [x] Regression tests: multi-line/single-line quoted force-push and lifecycle/cloud data literals (echo/printf/`--body`) allow.
- [x] Safety floor preserved and tested: genuine force-push/lifecycle commands, `$(`/backtick smuggling, `bash -c`/`sh -c`, and pipe-to-shell still deny (verified both directions).
- [x] Full suite via `hooks/repo/tests/run.sh` green, breakdown self-check passes.

## Test Plan

- `pnpm test` (= `hooks/repo/tests/run.sh`): **809 pass / 0 fail**; `test-guard-destructive.sh` 470 -> **488** (+18 `#71` cases).
- Manual repro against the branch guard: multi-line quoted force-push and quoted `halt`/`reboot`/`poweroff`/`shutdown`/`az|gcloud delete` now **allow**.
- Safety floor manually confirmed still **deny**: genuine unquoted multi-line danger (force-push, `halt`, `az delete` on a later line), `$(...)` and backtick smuggling inside the quoted literal, `bash -c`/`sh -c` line-leading force-push payload, and pipe-to-`sh`.
- Fault injection: the new `#71` allow-cases were run against the unpatched `origin/main` guard and reproduced the defects (force-push -> `ask`, `halt` -> `deny`), confirming the tests exercise the fix.

Note on the lifecycle safety floor: `sh -c 'halt'` / `echo halt | sh` allow on `origin/main` too (lifecycle words inside an inert `-c`/pipe quote are never parsed as a command word, and `halt` is not a raw catastrophic pattern like force-push). That is a pre-existing limitation independent of this multi-line fix, so those specific shapes are intentionally not asserted for the lifecycle parser; the `-c`/pipe safety-floor cases use the force-push phrase (a raw catastrophic pattern), exactly as `#60` used its recursive-delete phrase.

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)
