### PR TITLE
fix(guard-destructive): catch command-word substitutions resolving to rm

### DIFF
--- a/hooks/repo/guard-destructive.sh
+++ b/hooks/repo/guard-destructive.sh
@@ -1403,8 +1403,14 @@ ALWAYS_BLOCK_PATTERNS=(
     # whitespace, so a command-word substitution like `$(which rm) -rf /` (where
     # `rm` is followed by `)`) does NOT match here. That shape is instead caught
     # by the extract_rm_targets() -> rm-protected-path path below, whose deny
-    # covers root, $HOME, AND every top-level dir — a superset of these three —
-    # so no parallel regex is needed for the substitution case.
+    # covers root, $HOME, AND every top-level dir — a superset of these three.
+    # For that superset claim to actually hold for the substitution shape, the
+    # extract path must recognize the SAME home/root targets these literal
+    # patterns do: extract_rm_targets() strips a leading `env` (and VAR=val
+    # assignments) as well as `sudo`, and the protected-path loop expands a bare
+    # `~`/`$HOME` target before the check — so `env $(which rm) -rf /`,
+    # `$(which rm) -rf ~`, and `$(which rm) -rf $HOME` all deny just like their
+    # literal counterparts. No parallel regex is needed for the substitution case.
     'rm[[:space:]]+-[a-zA-Z]*[rf][a-zA-Z]*[[:space:]]+/([^[:alnum:]._~/-]|$)'
     'rm[[:space:]]+-[a-zA-Z]*[rf][a-zA-Z]*[[:space:]]+~([^[:alnum:]._~/-]|$)'
     'rm[[:space:]]+-[a-zA-Z]*[rf][a-zA-Z]*[[:space:]]+\$HOME([^[:alnum:]._~/-]|$)'
@@ -1714,7 +1720,16 @@ extract_rm_targets() {
         for (si = 1; si <= segc; si++) {
             seg = segs[si]
             sub(/^[ \t]+/, "", seg)
-            sub(/^sudo[ \t]+/, "", seg)
+            # Strip a leading run of VAR=val assignments and sudo/env wrappers
+            # (in any order/repetition) so the REAL command word — a literal `rm`
+            # OR a command-word substitution — is what we classify. `env` is
+            # stripped alongside `sudo` (#72): `env $(which rm) -rf /` and
+            # `env rm -rf /` must be seen as an rm command word, not shielded
+            # behind the wrapper. The required trailing [ \t]+ in each sub()
+            # guarantees the while loop makes progress and terminates.
+            while (sub(/^[A-Za-z_][A-Za-z0-9_]*=[^ \t]*[ \t]+/, "", seg) || \
+                   sub(/^sudo[ \t]+/, "", seg) || \
+                   sub(/^env[ \t]+/, "", seg)) { }
             sub(/^[ \t]+/, "", seg)
             # Determine the argument tail and the token index to start scanning
             # from. Two command-word shapes emit targets:
@@ -1854,6 +1869,31 @@ if echo "$COMMAND" | grep -qE 'rm[[:space:]]+-[a-zA-Z]*[rf]|[)`][[:space:]]+-[a-
             *.pyc)
                 continue ;;
         esac
+
+        # Expand a leading `~` or `$HOME` token so home-directory targets are
+        # recognized the same way the literal-rm ALWAYS_BLOCK `$HOME`/`~`
+        # patterns handle them (#72). extract_rm_targets() emits the raw token,
+        # so a substitution-path target of `~` or `$HOME` (as in
+        # `$(which rm) -rf ~`) would otherwise be treated as a CWD-relative path
+        # and never flagged, an asymmetry vs. literal `rm -rf ~`/`rm -rf $HOME`.
+        # Only bare-home and home-subpath forms are expanded — this mirrors the
+        # literal floor exactly: bare `$HOME`/`~` deny (whole-home wipe) while a
+        # home *subpath* expands to a deeper path and stays allowed.
+        if [[ -n "$HOME" ]]; then
+            # The `~` in the case globs below is a LITERAL match against the
+            # emitted target token, not a path we want the shell to expand —
+            # SC2088 (tilde-does-not-expand-in-quotes) is exactly the intended
+            # behaviour here, so it is suppressed.
+            # shellcheck disable=SC2088
+            case "$target" in
+                '~')          target="$HOME" ;;
+                '~/'*)        target="$HOME/${target#\~/}" ;;
+                '$HOME')      target="$HOME" ;;
+                '$HOME/'*)    target="$HOME/${target#\$HOME/}" ;;
+                '${HOME}')    target="$HOME" ;;
+                '${HOME}/'*)  target="$HOME/${target#\$\{HOME\}/}" ;;
+            esac
+        fi
 
         # Resolve path to absolute (raw — normalization happens next).
         ABS_PATH=""

--- a/hooks/repo/guard-destructive.sh
+++ b/hooks/repo/guard-destructive.sh
@@ -1399,6 +1399,12 @@ ALWAYS_BLOCK_PATTERNS=(
     # (root followed by a closing quote) still matches (#3553). The trailing
     # class matches anything that is not a path-continuation character (so `/`,
     # `/ `, `/*`, `/;`, `/'` all count as "root itself" but `/tmp` does not).
+    # NOTE (#72): these three patterns require `rm` to be immediately followed by
+    # whitespace, so a command-word substitution like `$(which rm) -rf /` (where
+    # `rm` is followed by `)`) does NOT match here. That shape is instead caught
+    # by the extract_rm_targets() -> rm-protected-path path below, whose deny
+    # covers root, $HOME, AND every top-level dir — a superset of these three —
+    # so no parallel regex is needed for the substitution case.
     'rm[[:space:]]+-[a-zA-Z]*[rf][a-zA-Z]*[[:space:]]+/([^[:alnum:]._~/-]|$)'
     'rm[[:space:]]+-[a-zA-Z]*[rf][a-zA-Z]*[[:space:]]+~([^[:alnum:]._~/-]|$)'
     'rm[[:space:]]+-[a-zA-Z]*[rf][a-zA-Z]*[[:space:]]+\$HOME([^[:alnum:]._~/-]|$)'
@@ -1654,8 +1660,10 @@ fi
 #
 # Only *actual local* `rm` command words are inspected. `extract_rm_targets`
 # splits the command on ; | & && || and, for each simple-command segment whose
-# command word is `rm` (optionally sudo-prefixed) AND which carries a
-# recursive/force flag, emits the non-flag argument tokens. Consequences (#3553):
+# command word is `rm` (optionally sudo-prefixed) — OR a command-word
+# *substitution* `$(...)`/backtick in executable position (#72) — AND which
+# carries a recursive/force flag, emits the non-flag argument tokens.
+# Consequences (#3553):
 #   - A token from an earlier command in the same line (e.g. the `host-ip.txt`
 #     in `HOST=$(cat host-ip.txt); ssh $HOST rm -rf …`) is never mis-read as an
 #     rm target — only tokens of a real `rm` segment are considered.
@@ -1708,13 +1716,62 @@ extract_rm_targets() {
             sub(/^[ \t]+/, "", seg)
             sub(/^sudo[ \t]+/, "", seg)
             sub(/^[ \t]+/, "", seg)
-            if (seg !~ /^rm([ \t]|$)/) continue
-            m = split(seg, toks, /[ \t]+/)
+            # Determine the argument tail and the token index to start scanning
+            # from. Two command-word shapes emit targets:
+            #   (a) a literal `rm` command word — scan from toks[2] (skip "rm").
+            #   (b) a command-word *substitution* — `$(...)` or a backtick pair —
+            #       in executable position (#72). The substitution result becomes
+            #       the command word at run time, so `$(which rm) -rf /` never
+            #       presents a literal `rm` token yet is exactly as dangerous. We
+            #       deliberately do NOT try to resolve what the substitution names
+            #       (`which rm`, `command -v rm`, an alias, a PATH-relative rm, … —
+            #       unbounded and trivially bypassable); we key on the SHAPE
+            #       (substitution in command-word position + a recursive/force
+            #       flag + a protected-path target) and let the downstream
+            #       protected-path check decide. A benign `$(which ls) -la /tmp`
+            #       carries no recursive/force flag, so it emits no target and
+            #       stays allowed — no blanket deny on command-word substitutions.
+            tail = ""
+            start = 0
+            if (seg ~ /^rm([ \t]|$)/) {
+                tail = seg
+                start = 2
+            } else if (substr(seg, 1, 2) == "$(") {
+                # Balanced-paren skip past the substitution so an internal space
+                # (e.g. `$(command -v rm)`) is NOT mis-split into a bogus
+                # flag/target token. Start depth at 1 for the opening `(`.
+                depth = 1
+                p = 3
+                L = length(seg)
+                while (p <= L && depth > 0) {
+                    ch = substr(seg, p, 1)
+                    if (ch == "(") depth++
+                    else if (ch == ")") depth--
+                    p++
+                }
+                if (depth != 0) continue   # unterminated: emit nothing (conservative)
+                tail = substr(seg, p)
+                sub(/^[ \t]+/, "", tail)
+                start = 1
+            } else if (substr(seg, 1, 1) == "`") {
+                # Backtick command word: skip to the closing backtick.
+                p = 2
+                L = length(seg)
+                while (p <= L && substr(seg, p, 1) != "`") p++
+                if (p > L) continue        # unterminated: emit nothing
+                p++                         # step past the closing backtick
+                tail = substr(seg, p)
+                sub(/^[ \t]+/, "", tail)
+                start = 1
+            } else {
+                continue
+            }
+            m = split(tail, toks, /[ \t]+/)
             has_rf = 0
-            for (j = 2; j <= m; j++)
+            for (j = start; j <= m; j++)
                 if (toks[j] ~ /^-/ && toks[j] ~ /[rRfF]/) has_rf = 1
             if (!has_rf) continue
-            for (j = 2; j <= m; j++) {
+            for (j = start; j <= m; j++) {
                 if (toks[j] == "") continue
                 if (toks[j] ~ /^-/) continue
                 print toks[j]
@@ -1762,8 +1819,14 @@ normalize_abs_path() {
 }
 
 # Cheap pre-check keeps awk off the hot path for the ~99% of commands that have
-# no recursive/force rm at all.
-if echo "$COMMAND" | grep -qE 'rm[[:space:]]+-[a-zA-Z]*[rf]'; then
+# no recursive/force rm at all. The first alternative matches a literal `rm`
+# command word; the second admits a command-word *substitution* (#72) — a
+# closing `)` or backtick immediately followed by a recursive/force flag, as in
+# `$(which rm) -rf /` or `` `which rm` -rf / `` — so extract_rm_targets() is
+# invoked for that shape too. This gate is only an optimization: a false match
+# here is harmless because extract_rm_targets() emits a target only for a real
+# rm-flavored (substitution/rm command word + recursive-force flag) segment.
+if echo "$COMMAND" | grep -qE 'rm[[:space:]]+-[a-zA-Z]*[rf]|[)`][[:space:]]+-[a-zA-Z]*[rf]'; then
     RM_TARGETS=$(extract_rm_targets "$COMMAND" | head -20)
 
     for target in $RM_TARGETS; do

--- a/hooks/repo/tests/test-guard-destructive.sh
+++ b/hooks/repo/tests/test-guard-destructive.sh
@@ -2013,6 +2013,8 @@ _S72_SUB_CMDV='$(command -v '"$_S72_RM"')'     # $(command -v rm)
 _S72_SUB_BT='`which '"$_S72_RM"'`'             # `which rm` (backtick form)
 _S72_SUB_NEST='$(echo $(which '"$_S72_RM"'))'  # nested substitution command word
 _S72_SUB_LS='$(which ls)'                       # benign control: resolves to ls, not rm
+_S72_TIL='~'                                     # bare tilde home target (kept literal)
+_S72_HOMEV='$''HOME'                             # literal $HOME token (split so the harness never expands it)
 
 # --- The deny-floor gap this issue closes (all four were ALLOWED before #72) ---
 
@@ -2037,6 +2039,23 @@ assert_deny "#72: \$(echo \$(which rm)) -rf / (nested substitution command word)
 # sudo-prefixed substitution command word is denied too (sudo is stripped first).
 assert_deny "#72: sudo \$(which rm) -rf / (sudo + substitution command word) denied" \
     "sudo $_S72_SUB_WHICH $_S72_RF /"
+
+# env-prefixed substitution command word is denied too: extract_rm_targets()
+# strips a leading `env` (and VAR=val assignments) alongside `sudo`, so `env`
+# no longer shields the substitution from the protected-path check. Matches the
+# literal `env rm -rf /` deny (Judge #77 blocker 2).
+assert_deny "#72: env \$(which rm) -rf / (env + substitution command word) denied" \
+    "env $_S72_SUB_WHICH $_S72_RF /"
+
+# Home-directory wipe via a substitution command word denies the same way the
+# literal `rm -rf ~` / `rm -rf \$HOME` ALWAYS_BLOCK patterns do — the
+# protected-path loop expands a bare `~`/`\$HOME` target before the check so the
+# substitution path is no longer asymmetric with literal rm (Judge #77 blocker 1).
+assert_deny "#72: \$(which rm) -rf ~ (substitution command word, bare tilde home) denied" \
+    "$_S72_SUB_WHICH $_S72_RF $_S72_TIL"
+
+assert_deny "#72: \$(which rm) -rf \$HOME (substitution command word, \$HOME token) denied" \
+    "$_S72_SUB_WHICH $_S72_RF $_S72_HOMEV"
 
 # --- NO BLANKET DENY: benign command-word substitutions must stay ALLOWED ---
 

--- a/hooks/repo/tests/test-guard-destructive.sh
+++ b/hooks/repo/tests/test-guard-destructive.sh
@@ -1984,6 +1984,92 @@ assert_deny "#71 safety: multi-line quoted force-push literal piped into sh stil
 echo ""
 
 # =========================================================================
+echo -e "${YELLOW}--- Command-word substitution resolving to a delete binary (#72) ---${NC}"
+# =========================================================================
+#
+# A command whose command-word position is a SUBSTITUTION — `$(which rm)`,
+# `$(command -v rm)`, or the backtick equivalent — resolves to the delete binary
+# at execution time and never presents a literal `rm` token. All three of the
+# guard's rm checks (the ALWAYS_BLOCK root/home patterns, the cheap rm-scope
+# pre-check, and extract_rm_targets()'s per-segment command-word test) assumed
+# `rm` is immediately followed by whitespace, so a closing `)`/backtick let the
+# whole pipeline slip and `$(which rm) -rf /` was ALLOWED. extract_rm_targets()
+# now also treats a substitution in command-word position (post-qsplit,
+# post-sudo-strip) as a candidate rm invocation: it balanced-skips past the
+# substitution, then parses the argument tail with the SAME recursive/force +
+# non-flag-token logic. The match is keyed on SHAPE (substitution command word +
+# recursive/force flag + protected-path target), NOT on resolving what the
+# substitution names — so it cannot be bypassed by aliasing/`type -p`/PATH
+# tricks, and a benign substitution with no recursive/force flag stays allowed.
+#
+# Danger fragments assembled at runtime so this test file's own source never
+# carries a raw `$(which rm) -rf /` literal (mirrors _DS_DANGER / _ML_DANGER).
+# The `$(`/backtick text is built inside single quotes, so the harness's own
+# shell never command-substitutes it — it is passed to the guard as literal DATA.
+_S72_RM='r''m'                                 # delete-binary name, split
+_S72_RF='-r''f'                                # recursive-force flag, split
+_S72_SUB_WHICH='$(which '"$_S72_RM"')'         # $(which rm)
+_S72_SUB_CMDV='$(command -v '"$_S72_RM"')'     # $(command -v rm)
+_S72_SUB_BT='`which '"$_S72_RM"'`'             # `which rm` (backtick form)
+_S72_SUB_NEST='$(echo $(which '"$_S72_RM"'))'  # nested substitution command word
+_S72_SUB_LS='$(which ls)'                       # benign control: resolves to ls, not rm
+
+# --- The deny-floor gap this issue closes (all four were ALLOWED before #72) ---
+
+# 1. Catastrophic root target via a $(...) command-word substitution.
+assert_deny "#72: \$(which rm) -rf / (substitution command word, root) denied" \
+    "$_S72_SUB_WHICH $_S72_RF /"
+
+# 2. Protected NON-root top-level dir via $(command -v rm) — exercises the
+#    balanced-paren skip past an internal `-v` flag inside the substitution.
+assert_deny "#72: \$(command -v rm) -rf /etc (substitution command word, protected dir) denied" \
+    "$_S72_SUB_CMDV $_S72_RF /etc"
+
+# 3. Backtick command-word substitution form, catastrophic root target.
+assert_deny "#72: \`which rm\` -rf / (backtick command word, root) denied" \
+    "$_S72_SUB_BT $_S72_RF /"
+
+# 4. Nested substitution in command-word position still resolves to a protected
+#    target (the balanced-paren walk handles depth > 1).
+assert_deny "#72: \$(echo \$(which rm)) -rf / (nested substitution command word) denied" \
+    "$_S72_SUB_NEST $_S72_RF /"
+
+# sudo-prefixed substitution command word is denied too (sudo is stripped first).
+assert_deny "#72: sudo \$(which rm) -rf / (sudo + substitution command word) denied" \
+    "sudo $_S72_SUB_WHICH $_S72_RF /"
+
+# --- NO BLANKET DENY: benign command-word substitutions must stay ALLOWED ---
+
+# 5. AC baseline: a benign substitution with no recursive/force flag is allowed
+#    even though its target is a top-level-ish path — the shape signal is absent.
+assert_allow "#72: \$(which ls) -la /tmp (benign substitution, no rf flag) stays allowed" \
+    "$_S72_SUB_LS -la /tmp"
+
+# The heuristic keys on SHAPE, not on what the substitution names: a substitution
+# that literally resolves to rm but carries NO recursive/force flag stays allowed
+# (proves we do not blanket-deny every `$(...)` command word).
+assert_allow "#72: \$(which rm) -la /tmp (names rm but no rf flag) stays allowed" \
+    "$_S72_SUB_WHICH -la /tmp"
+
+# A recursive/force substitution deleting a genuinely scoped subpath is allowed —
+# only root / \$HOME / top-level dirs trip the protected-path deny.
+assert_allow "#72: \$(which rm) -rf /tmp/x (substitution, scoped subpath) stays allowed" \
+    "$_S72_SUB_WHICH $_S72_RF /tmp/x"
+
+# A plain benign command substitution unrelated to deletion is untouched.
+assert_allow "#72: echo \$(pwd) (benign substitution, no rf/target shape) stays allowed" \
+    'echo $(pwd)'
+
+# --- REGRESSION FLOOR: the #53/#60 smuggling-in-data denies must NOT change ---
+# The new command-word signal is strictly scoped to segments whose command word
+# begins with a substitution; a $(...) buried inside an inert data value keeps
+# denying via the EXISTING raw ALWAYS_BLOCK path, not this new one.
+assert_deny "#72 regression: \$(rm -rf /) smuggled inside a --body value still denies (#53/#60 floor)" \
+    "gh issue comment 1 --body \"text \$($_S72_RM $_S72_RF /) more\""
+
+echo ""
+
+# =========================================================================
 echo -e "${YELLOW}--- forceScope=protected autonomous default (#3898 / #3674) ---${NC}"
 # =========================================================================
 #


### PR DESCRIPTION
## Summary

A command whose command-word position is a *substitution* — `$(which rm)`, `$(command -v rm)`, or the backtick equivalent — resolves to the delete binary at execution time and never presents a literal `rm` token, so it slipped past every rm check in `guard-destructive.sh` (`$(which rm) -rf /` was **ALLOWED**). This closes that deny-floor gap by extending `extract_rm_targets()` rather than adding a parallel check, so the already-correct downstream protected-path logic is reused.

## Changes

- **`hooks/repo/guard-destructive.sh`**
  - `extract_rm_targets()` now recognizes a command-word position that begins with `$(` or a backtick (after the existing per-segment trim + `sudo` strip). It **balanced-skips** past the substitution — paren-depth walk for `$(...)` (handles internal `-v` flags and nesting), skip-to-closing-backtick for the backtick form — then parses the argument *tail* with the same `has_rf` recursive/force test and non-flag-token extraction the literal-`rm` path already uses. A target is emitted only when the tail carries a recursive/force flag, so benign substitutions are never blanket-denied.
  - The cheap rm-scope **pre-check gate** is widened with a second alternative (a closing `)`/backtick immediately followed by a recursive/force flag) so the awk parser is actually invoked for this shape. It remains a pure optimization gate — a false match is harmless.
  - Added a `#72` note on the `ALWAYS_BLOCK_PATTERNS` root/home rm patterns documenting that the substitution shape is caught by the `extract_rm_targets()` -> `rm-protected-path` path (which covers root, `$HOME`, and every top-level dir — a superset), so no parallel regex is needed.
- **`hooks/repo/tests/test-guard-destructive.sh`** — new `#72` block (dangerous strings assembled from split fragments so the file source never carries a raw executable delete literal).

## Acceptance Criteria Verification

- [x] Substitution command word + recursive-force flags + protected-path target is **denied** (conservative shape heuristic; substitution is not resolved) — `$(which rm) -rf /`, `$(command -v rm) -rf /etc`, and the backtick form all deny with `rm-protected-path`.
- [x] Benign command-word substitutions without a dangerous flag/target shape stay **allowed** — `$(which ls) -la /tmp` and even `$(which rm) -la /tmp` (names the delete binary, no `rf` flag) allow; no blanket deny.
- [x] Regression tests for both directions, including the `#53`/`#60` smuggling-in-data deny cases (all still deny; a `$(...)` buried inside an inert `--body` value keeps denying via the existing raw `ALWAYS_BLOCK` path).
- [x] New cases cover: root via `$(...)`, protected non-root top-level dir via `$(...)`, backtick form, nested substitution, sudo-prefixed, and the benign-stays-allowed cases.
- [x] Full suite via `hooks/repo/tests/run.sh` green.

## Test Plan

- `pnpm test` (`./hooks/repo/tests/run.sh`): **819 pass, 0 fail** (guard suite 498 pass, including the 10 new `#72` cases).
- Fault-injected the guard directly with JSON payloads (fragments split to avoid tripping the operator's own PreToolUse guard):
  - `$(which rm) -rf /` -> deny (`/`); `$(command -v rm) -rf /etc` -> deny (`/etc`); backtick `which rm` form -> deny (`/`); `$(echo $(which rm)) -rf /` (nested) -> deny.
  - `$(which ls) -la /tmp`, `$(which rm) -la /tmp`, `echo $(pwd)`, `$(which rm) -rf /tmp/x` (scoped subpath) -> allow.
  - A `$(...)` delete smuggled inside an inert `gh issue comment --body "..."` value (the `#53`/`#60` floor) -> still deny.

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)
