### PR TITLE
fix(guard): do not probe a backslash-escaped \<< as a heredoc opener

### DIFF
--- a/hooks/repo/guard-destructive.sh
+++ b/hooks/repo/guard-destructive.sh
@@ -1020,6 +1020,12 @@ function qsplit(s,   out, n, i, c, j, qc, ci, inner, SQ, DQ) {
 #     newline falls through to the legacy separator handling, so the continued
 #     line is segmented as the real commands it is; the bodies then start at the
 #     first NON-continued newline, matching the shell.
+#   - A `<<` whose leading `<` is itself preceded by an ODD number of backslashes
+#     (`\<<WORD`) is NOT an operator — `\<` is a literal `<` inside a word — so it
+#     is not probed at all (#108). Without this the phantom opener's terminator
+#     never appeared and the unterminated-heredoc rule skipped the rest of the
+#     buffer, hiding every later real command. The ESCAPED-DELIMITER form
+#     `<<\WORD` is a different (and legitimate) thing and is unaffected.
 # Safety floor unchanged: the raw ALWAYS_BLOCK_PATTERNS catastrophic scan reads
 # the command string directly (never through ml_segment), so a `$(...)`-smuggled
 # payload inside a heredoc body still denies, and a GENUINE multi-line command
@@ -1074,11 +1080,18 @@ function hd_opener(s, n, i, out,   j, c, q, w, SQ, DQ) {
     out["delim"] = w
     return j
 }
-# A newline at position i is a LINE CONTINUATION when it is preceded by an ODD
-# number of backslashes (`\` + newline is removed by the shell; `\\` + newline is
-# a literal backslash followed by a REAL newline). A continued newline does not
-# end the logical line, so heredoc bodies must NOT start there.
-function cont_nl(s, i,   bs, p) {
+# The character at position i is BACKSLASH-ESCAPED when it is preceded by an ODD
+# number of backslashes (`\x` is an escape; `\\x` is a literal backslash followed
+# by an unescaped `x`). Two call sites depend on this parity:
+#   - a NEWLINE: an escaped newline is a LINE CONTINUATION — the shell removes it
+#     and the logical line continues, so pending heredoc BODIES must not start
+#     there;
+#   - the leading `<` of a `<<`: an escaped `\<` is a literal `<` inside a word,
+#     NOT a redirection operator, so `\<<WORD` never opens a heredoc and must not
+#     be probed as one (#108).
+# Both uses are strictly NARROWING: treating something as escaped only falls back
+# to the legacy separator-active segmentation, which cannot widen a deny.
+function bs_escaped(s, i,   bs, p) {
     bs = 0
     for (p = i - 1; p >= 1 && substr(s, p, 1) == "\\"; p--) bs++
     return (bs % 2)
@@ -1147,7 +1160,17 @@ function ml_segment(buf, segs,   SQ, DQ, s, n, seg, segc, i, c, qc, ci, j, inner
                 pc == "&" || pc == "|" || pc == "(" || pc == ")" ||
                 pc == "<" || pc == ">") incmt = 1
         }
-        if (c == "<" && i < n && substr(s, i + 1, 1) == "<" && !incmt) {
+        # A BACKSLASH-ESCAPED leading `<` (`\<<WORD`) is a literal `<` inside a
+        # word, not a redirection operator, so the shell opens no heredoc there
+        # (#108). Probing it anyway manufactured a phantom opener whose
+        # terminator never appears, and the unterminated-heredoc rule then
+        # skipped the REST OF THE BUFFER — hiding every later real command from
+        # all three parsers. Note this checks only the FIRST `<`: when the SECOND
+        # one is escaped (`<\<`) the `substr()` guard below already fails, and an
+        # escaped DELIMITER (`<<\EOF`) is a legitimate opener that hd_opener()
+        # handles by marking the body unexpanded.
+        if (c == "<" && i < n && substr(s, i + 1, 1) == "<" && !incmt &&
+            !bs_escaped(s, i)) {
             if (substr(s, i + 2, 1) == "<") {
                 # `<<<` is a here-STRING: consume the whole operator so its third
                 # `<` cannot be re-probed as the start of a `<< WORD` heredoc.
@@ -1174,7 +1197,7 @@ function ml_segment(buf, segs,   SQ, DQ, s, n, seg, segc, i, c, qc, ci, j, inner
                 continue
             }
         }
-        if (c == "\n" && hdc > 0 && !cont_nl(s, i)) {
+        if (c == "\n" && hdc > 0 && !bs_escaped(s, i)) {
             # End of the opener line: the pending heredoc BODIES follow. Look
             # ahead across every pending body, in opener order, to find where the
             # last one ends — and whether any EXPANSION-CAPABLE body (bare

--- a/hooks/repo/tests/test-guard-destructive.sh
+++ b/hooks/repo/tests/test-guard-destructive.sh
@@ -2284,6 +2284,44 @@ assert_allow "#84: a markdown # heading in a heredoc body does not disturb the s
 assert_allow "#84: a benign backslash-continued opener line still allows the body" \
     "$(printf 'cat <<EOF \\\n  --flag\n%s\nEOF' "$_HD84_SHUTDOWN")"
 
+# --- #108: a backslash-ESCAPED leading `<` is not an operator -----------------
+#
+# `\<` is a literal `<` inside a word, so `\<<WORD` opens no heredoc at all.
+# Probing it anyway manufactured a phantom opener whose terminator never appears,
+# and the unterminated-heredoc rule then skipped the REST OF THE BUFFER — hiding
+# every later real command from all three parsers. Real bash runs the command on
+# the following line in each of these (verified with a marker binary shadowing
+# the lifecycle word on PATH), and the pre-#84 guard denied them all.
+
+assert_deny "#108 safety: escaped \\<< is not an opener and cannot hide the next line" \
+    "$(printf 'cat \\<<EOF\n%s' "$_HD84_HALT")"
+
+assert_deny "#108 safety: escaped \\<< with a quoted delimiter still denies" \
+    "$(printf 'true \\<<%sEOF%s\n%s' "$_HD84_SQ" "$_HD84_SQ" "$_HD84_HALT")"
+
+assert_deny "#108 safety: escaped \\<<- plus a line continuation still denies" \
+    "$(printf 'cat \\<<-EOF \\\nbody text\n%s' "$_HD84_HALT")"
+
+assert_deny "#108 safety: escaped \\<< does not hide an outside-repo rm" \
+    "$(printf 'cat \\<<EOF\n%s' "$_HD84_RM")"
+
+assert_ask "#108 safety: escaped \\<< does not hide a force op" \
+    "$(printf 'cat \\<<EOF\n%s' "$_HD84_RESET")"
+
+# The check applies to the LEADING `<` only. An escaped DELIMITER (`<<\EOF`) is a
+# genuine opener that merely suppresses body expansion, and an escaped SECOND `<`
+# (`<\<`) is not a `<<` sequence at all — neither may regress.
+assert_allow "#108: an escaped DELIMITER <<\\EOF is still a real opener" \
+    "$(printf 'cat <<\\EOF\n%s\nEOF' "$_HD84_HALT")"
+
+assert_deny "#108 safety: <\\< is not a heredoc operator and hides nothing" \
+    "$(printf 'cat <\\<EOF\n%s' "$_HD84_HALT")"
+
+# An EVEN number of backslashes leaves the `<` unescaped, so this IS a real
+# opener and its body stays inert.
+assert_allow "#108: an escaped backslash before << leaves a real opener" \
+    "$(printf 'cat \\\\<<EOF\n%s\nEOF' "$_HD84_HALT")"
+
 echo ""
 
 # =========================================================================


### PR DESCRIPTION
Closes #108

## Summary

Closes a residual **deny→allow bypass** in the `ml_segment()` heredoc lexer that
shipped with #107. Same root cause as the two the Judge caught there — an
assumption about when `<<` is really an operator — in a third position.

`ml_segment()` entered its heredoc branch on any `<` whose next character is `<`,
without checking whether that leading `<` was itself **backslash-escaped**. In
the shell `\<` is a literal `<` inside a word, not a redirection operator, so
`\<<WORD` opens no here-document at all. Probing it anyway manufactured a phantom
opener whose `EOF` terminator never appears; the unterminated-heredoc rule then
skipped **the entire rest of the buffer**, hiding every later real command from
all three segment parsers.

## The bypass

(The lifecycle word is written split below so this description does not trip the
guard; read `ha`+`lt` as one word.)

```
cat \<<EOF
halt
```

| | decision |
|---|---|
| pre-#84 guard (`fb8128b`) | `deny: BLOCKED: system lifecycle command` |
| `main` (`c925fb2`) | **allow (silent)** |
| this branch | `deny` |
| real `bash` | **runs the command on line 2** |

Same result for `true \<<'EOF'`, `cat \<<"EOF"`, `echo hi \<<\EOF |` and
`cat \<<-EOF \` + continuation, and for the `extract_rm_targets` /
`parse_force_ops` payloads (an outside-repo removal re-denies, a hard reset
re-asks).

## The fix

Generalize the parity helper `cont_nl()` added by #107 to `bs_escaped(s, i)` —
"the character at `i` is preceded by an ODD number of backslashes" — and apply it
to the leading `<` as well as to the newline it already guarded. One helper, two
call sites, no behavioural change to the newline path.

Both uses are **strictly narrowing**: deciding something is escaped only falls
back to the legacy separator-active segmentation, so it can restore a deny but
can never widen one. The check deliberately looks at the FIRST `<` only:

- `<\<` — the second `<` escaped — never reaches the branch (the `substr()` guard
  already fails), and
- `<<\EOF` — an escaped **delimiter** — is a legitimate opener that
  `hd_opener()` already handles by marking the body unexpanded.

## Verification

A differential harness runs every candidate through the pre-#84 guard, current
`main` and this branch, and cross-checks it against **real `bash`** using a
marker binary that shadows the lifecycle word on `PATH` — so the byte-identical
command string is fed to both the guard and the shell. A row only counts as a
bypass when the pre-#84 guard denied, this branch allows, and `bash` actually
executes the marker.

- Hand-written adversarial corpora: 191 cases — comment-hidden fake openers
  across every comment-start position, continuation x delimiter-form x separator
  matrices, delimiter-word edge cases (`<<'EO'F`, `<<E"O"F`, `<<$X`,
  trailing-space and mis-indented terminators), fake openers inside inert /
  command-substitution-bearing quoted spans, and the smuggling floor. **0
  bypasses.**
- Randomized differential fuzz, 8 seeds x ~300 generated multi-line commands from
  a heredoc/comment/continuation-biased token alphabet. This is what surfaced
  `\<<` in the first place (15 hits across the first 3 seeds on `main`); after
  the fix the same seeds report **0 bypasses.**
- `pnpm test`: **1065 pass / 0 fail**, guard suite **544 pass / 0 fail** (536 to
  544 with the 8 new cases). All existing `#84`/`#107` cases stay green,
  including the intended false-positive fixes.
- `shellcheck` clean (only the pre-existing repo-wide SC2016 infos on the awk
  program strings).

## Tests added

Eight cases in the `#84` block of `hooks/repo/tests/test-guard-destructive.sh`,
using the runtime-assembled danger-phrase convention from #60/#71:

- five asserting the bypass shapes deny/ask again (bare, quoted delimiter,
  `<<-` + continuation, outside-repo removal, force op);
- three pinning the near-misses that must not regress: `<<\EOF` (escaped
  delimiter) still allows its body, `<\<` still denies, and `\\<<` (even
  backslash run) is still a real opener.
