### PR TITLE
feat: gate repo-remote reuse of fleet-marked hosts behind --force

### DIFF
--- a/commands/repo/remote.md
+++ b/commands/repo/remote.md
@@ -44,6 +44,7 @@ loom's `fleet add-worker`) invokes directly:
 ```
 repo-remote up [aws|gcp]              # DRY RUN: print the resolved plan + estimated cost as JSON, create NOTHING
 repo-remote up --yes [--json]        # provision (or reuse) with no prompts; requires pre-supplied cost-relevant config
+repo-remote up --yes --force         # additionally override the fleet-marker guard (see below)
 repo-remote status [--json]          # list instances tagged repo-remote=<name>
 repo-remote down [--yes] [--delete]  # dry-run listing without --yes; stop (or --delete to terminate) with --yes
 ```
@@ -55,6 +56,17 @@ billable size on its own. Plain `repo-remote up` (no `--yes`) is a dry run that
 prints the plan and estimated hourly cost and spends nothing, so a caller can
 implement a "plan shown before money is spent" check against the `--json`
 output (instance id, public IP, SSH alias, estimated hourly cost).
+
+`--force` is a **separate** override with a single job: it lets `up` reuse an
+instance carrying a **fleet marker** (see [Fleet-marked hosts: the reuse
+guard](#fleet-marked-hosts-the-reuse-guard)). It does **not** relax the cost
+gate — `--force` without a pre-supplied `REPO_REMOTE_INSTANCE_TYPE` still fails
+loudly.
+
+Exit codes: `0` success (including a dry-run plan), `2` missing/invalid required
+config (the cost gate), `3` provider authentication failed, `4` cloud operation
+failed, `5` refused to reuse a fleet-marked instance (pass `--force`), `64`
+usage error.
 
 ## Configuration — two layers
 
@@ -129,6 +141,10 @@ REPO_REMOTE_SETUP="make setup"            # optional first-boot command; fallbac
 # --- session ---
 REPO_REMOTE_IDLE_SHUTDOWN_MIN=120         # interactive-host default; use ~20 for daemon-managed/worker hosts; 0 disables the guard entirely (see below)
 REPO_REMOTE_IDLE_MARKER=                   # optional idle-exit marker path (default: /var/run/repo-remote-daemon-idle.marker)
+
+# --- fleet-marker guard (refuse to reuse a managed fleet host) ---
+REPO_REMOTE_FLEET_TAG_KEY=Fleet           # tag (AWS) / label (GCP) key that marks a managed fleet host; empty disables the check
+REPO_REMOTE_FLEET_TAG_VALUE=loom          # required value for that key; empty means "any non-empty value counts"
 ```
 
 Only `REPO_REMOTE_PROVIDER` (or a provider argument) and that provider's
@@ -273,6 +289,11 @@ gcloud compute instances list --filter="labels.repo-remote=<name>" \
 
 RUNNING → offer reuse; STOPPED → offer to start.
 
+3. **Before starting or SSH-aliasing anything you *reused*** (either branch
+   above), check the resolved instance's tags/labels for a **fleet marker** and
+   stop unless `--force` was given — see **Fleet-marked hosts: the reuse guard**
+   below. A freshly created instance is never subject to this check.
+
 ### 4. Create the instance (with confirmation)
 
 **Before creating anything**, show the exact command, the machine spec
@@ -365,6 +386,56 @@ anything ever writes the file:
 On a daemon-managed host the two stages compose: the daemon's own idle-exit
 (writing the marker) is the first stage; this guard, `IDLE_MIN` minutes later, is
 the second and final stage that actually powers the box off.
+
+#### Fleet-marked hosts: the reuse guard
+
+The idle guard above is attached **once, at creation** — this command never
+re-attaches user-data to an instance it reuses, so the guard a host carries is
+whatever it got the day it was created. What reuse *does* do is **start a
+stopped instance and rewrite this repo's SSH alias to point at it**, and the
+handles it resolves that instance from — a pinned `REPO_REMOTE_INSTANCE_ID`, or
+the `repo-remote=<name>` tag/label — never expire. A box provisioned once for an
+ephemeral dev session can since have been repurposed into a persistent,
+daemon-managed fleet worker while still carrying the old tag, at which point
+ephemeral dev-session tooling would silently start and re-alias a production
+host. That is the second finding of the 2AMLogic/2am#52 incident, where
+`repo-remote=anvil` tooling kept rediscovering the host that had become
+`loom-worker-1`.
+
+**The check.** Before starting or aliasing a **reused** instance — on both AWS
+reuse branches (pinned id and `repo-remote=<name>` tag lookup) and on the GCP
+existing-instance branch — the resolved instance's **AWS tags** / **GCP labels**
+are read and matched against a fleet marker, by default **`Fleet=loom`** (the
+tag 2am's own remediation sets on its persistent workers). If it matches:
+
+- **Without `--force`**: the run **stops with exit `5`** and a message naming the
+  instance, the marker it found, and the override. Nothing is started, nothing is
+  terminated, and the SSH alias is left untouched.
+- **With `--force`**: it warns loudly that it is about to touch what looks like a
+  managed fleet host, then proceeds as normal.
+
+**Configuration.**
+
+- `REPO_REMOTE_FLEET_TAG_KEY` — the tag/label key to look for. Defaults to
+  `Fleet`. **Set it to the empty string to disable the check entirely.** GCP
+  label keys are lower-case, so the configured key is lower-cased for the GCP
+  lookup (`Fleet` → `labels.fleet`).
+- `REPO_REMOTE_FLEET_TAG_VALUE` — the value that counts as a match. Defaults to
+  `loom`; comparison is case-insensitive (GCP lower-cases label values). Set it
+  to the empty string to treat *any* non-empty value of the key as a match.
+
+**Scope — what this deliberately is not.** It is a **provisioning-time check
+against declared metadata** an operator already had to set elsewhere, not an
+on-host "is `loom-daemon` running" heuristic. The idle guard's activity model
+above is unchanged, and gains no process-name veto from this; the two are
+independent. It also does not fire on **creation** (a brand-new instance has no
+prior role to protect) or on a **dry run** (`repo-remote up` without `--yes`
+touches no cloud resource at all).
+
+**Related but distinct**: if the fleet host should also never power itself off,
+that is the idle guard's `REPO_REMOTE_IDLE_SHUTDOWN_MIN=0` opt-out above. This
+guard stops *this tooling* from touching the host; that one stops the *host*
+from shutting itself down.
 
 #### GPU hosts
 

--- a/commands/repo/tests/test-repo-remote.sh
+++ b/commands/repo/tests/test-repo-remote.sh
@@ -121,6 +121,12 @@ case "$1 $2" in
   "ec2 describe-images")
     echo "${MOCK_AWS_AMI:-ami-0ubuntu2204}"; exit 0 ;;
   "ec2 describe-instances")
+    # Fleet-marker lookup (repo#164) is also an --instance-ids call, so it must
+    # be matched FIRST by its Tags[?Key=...] query projection.
+    if printf '%s' "$*" | grep -qF "Tags[?Key=="; then
+      printf '%s\n' "${MOCK_AWS_FLEET_TAG:-None}"
+      exit 0
+    fi
     # --instance-ids (pinned lookup) vs --filters (tag find)
     if printf '%s' "$*" | grep -q -- '--instance-ids'; then
       echo "${MOCK_AWS_STATE:-None}"
@@ -152,6 +158,29 @@ case "$1 $2" in
 esac
 MOCK
 chmod +x "$MOCK_BIN/aws"
+
+# ---------------------------------------------------------------------------
+# A minimal mock `gcloud`, covering only the calls gcp_up() makes. Added for the
+# GCP half of the fleet-marker guard (repo#164) so the label-based check is
+# exercised, not just the AWS tag-based one.
+# ---------------------------------------------------------------------------
+cat >"$MOCK_BIN/gcloud" <<'MOCK'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"${MOCK_AWS_LOG:-/dev/null}"
+case "$1 $2 ${3:-}" in
+  "compute instances describe")
+    if printf '%s' "$*" | grep -qF 'labels.'; then
+      printf '%s\n' "${MOCK_GCP_FLEET_LABEL:-}"      # fleet-marker lookup
+    elif printf '%s' "$*" | grep -qF 'natIP'; then
+      printf '%s\n' "${MOCK_GCP_IP:-1.2.3.4}"        # public IP lookup
+    else
+      printf '%s\n' "${MOCK_GCP_STATE:-}"            # existence/status lookup
+    fi
+    exit 0 ;;
+esac
+exit 0
+MOCK
+chmod +x "$MOCK_BIN/gcloud"
 
 echo "repo-remote.sh test suite"
 echo "========================="
@@ -356,6 +385,104 @@ write_repo_env "REPO_REMOTE_INSTANCE_TYPE=m5.2xlarge"
 
 # ---------------------------------------------------------------------------
 echo ""
+echo "-- fleet-marker guard on AWS reuse discovery (repo#164) --"
+# ---------------------------------------------------------------------------
+# Reuse discovery (a pinned REPO_REMOTE_INSTANCE_ID, or the repo-remote=<name>
+# tag) resolves a handle that can outlive the host's role as an ephemeral dev
+# box. Starting/re-aliasing a host that has since become a fleet worker is the
+# second finding of 2AMLogic/2am#52, so a fleet marker on the resolved instance
+# must block the run unless --force is passed.
+
+# (a) Marker ABSENT -> behavior is exactly as before (reuse proceeds).
+write_repo_env "REPO_REMOTE_INSTANCE_TYPE=m5.2xlarge" "REPO_REMOTE_INSTANCE_ID=i-0pinned"
+run_rr MOCK_AWS_STATE=stopped MOCK_AWS_FLEET_TAG=None -- up --yes --json
+assert_eq   "no fleet marker: reuse still succeeds (exit 0)" "0" "$RR_RC"
+assert_contains "no fleet marker: still reports reused" "$RR_OUT" '"reused":true'
+assert_contains "no fleet marker: stopped instance still started" "$(cat "$MOCK_LOG")" "start-instances"
+
+# (b) Marker PRESENT, no --force -> blocked before any start/alias.
+SSH_BEFORE="$(cat "$SCRATCH/ssh_config" 2>/dev/null || true)"
+run_rr MOCK_AWS_STATE=stopped MOCK_AWS_FLEET_TAG=loom -- up --yes --json
+assert_eq   "fleet-marked pinned instance is refused (exit 5)" "5" "$RR_RC"
+assert_contains "message names the instance"          "$RR_ERR" "i-0pinned"
+assert_contains "message names the marker tag"        "$RR_ERR" "Fleet=loom"
+assert_contains "message points at the --force override" "$RR_ERR" "--force"
+assert_not_contains "blocked run emitted no up result" "$RR_OUT" '"action":"up"'
+assert_eq   "blocked run never started the instance" "0" "$(grep -c 'start-instances' "$MOCK_LOG" 2>/dev/null)"
+assert_eq   "blocked run never launched anything"    "0" "$(grep -c 'run-instances' "$MOCK_LOG" 2>/dev/null)"
+assert_eq   "blocked run left the SSH alias untouched" "$SSH_BEFORE" "$(cat "$SCRATCH/ssh_config" 2>/dev/null || true)"
+
+# (c) Marker PRESENT with --force -> proceeds, after a loud warning.
+run_rr MOCK_AWS_STATE=stopped MOCK_AWS_FLEET_TAG=loom -- up --yes --force --json
+assert_eq   "--force lets a fleet-marked instance through (exit 0)" "0" "$RR_RC"
+assert_contains "--force warns loudly first" "$RR_ERR" "WARNING"
+assert_contains "--force warning names the marker" "$RR_ERR" "Fleet=loom"
+assert_contains "--force run reuses the instance" "$RR_OUT" '"instance_id":"i-0pinned"'
+assert_contains "--force run actually started it" "$(cat "$MOCK_LOG")" "start-instances"
+
+# (d) The tag-discovery path (no pinned id) is guarded identically — this is the
+#     branch that let `repo-remote=<name>` tooling rediscover a fleet host.
+write_repo_env "REPO_REMOTE_INSTANCE_TYPE=m5.2xlarge"
+run_rr MOCK_AWS_FIND="i-0worker stopped" MOCK_AWS_FLEET_TAG=loom -- up --yes --json
+assert_eq   "fleet-marked tag-discovered instance is refused (exit 5)" "5" "$RR_RC"
+assert_contains "message names the discovered instance" "$RR_ERR" "i-0worker"
+assert_eq   "tag-discovery block never started it" "0" "$(grep -c 'start-instances' "$MOCK_LOG" 2>/dev/null)"
+run_rr MOCK_AWS_FIND="i-0worker stopped" MOCK_AWS_FLEET_TAG=loom -- up --yes --force --json
+assert_eq   "--force allows the tag-discovered instance" "0" "$RR_RC"
+assert_contains "--force reuses the discovered instance" "$RR_OUT" '"instance_id":"i-0worker"'
+
+# (e) A tag present with a DIFFERENT value is not this fleet's marker.
+write_repo_env "REPO_REMOTE_INSTANCE_TYPE=m5.2xlarge" "REPO_REMOTE_INSTANCE_ID=i-0pinned"
+run_rr MOCK_AWS_STATE=running MOCK_AWS_FLEET_TAG=someone-elses -- up --yes --json
+assert_eq "a non-matching Fleet value does not block" "0" "$RR_RC"
+
+# (f) The marker key/value are configurable, and an empty key disables the check.
+run_rr MOCK_AWS_STATE=running MOCK_AWS_FLEET_TAG=prod \
+  REPO_REMOTE_FLEET_TAG_KEY=Environment REPO_REMOTE_FLEET_TAG_VALUE=prod -- up --yes --json
+assert_eq   "custom marker key/value blocks (exit 5)" "5" "$RR_RC"
+assert_contains "message names the custom marker" "$RR_ERR" "Environment=prod"
+run_rr MOCK_AWS_STATE=running MOCK_AWS_FLEET_TAG=loom REPO_REMOTE_FLEET_TAG_KEY= -- up --yes --json
+assert_eq "empty REPO_REMOTE_FLEET_TAG_KEY disables the check" "0" "$RR_RC"
+
+# (g) The guard is a *reuse* check: a dry run touches nothing and is never blocked.
+run_rr MOCK_AWS_STATE=running MOCK_AWS_FLEET_TAG=loom -- up --json
+assert_eq "dry run is never blocked by the fleet marker" "0" "$RR_RC"
+assert_contains "dry run still prints the plan" "$RR_OUT" '"dry_run":true'
+write_repo_env "REPO_REMOTE_INSTANCE_TYPE=m5.2xlarge"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "-- fleet-marker guard on GCP reuse discovery (labels) --"
+# ---------------------------------------------------------------------------
+GCP_ENV=("REPO_REMOTE_PROVIDER=gcp" "REPO_REMOTE_INSTANCE_TYPE=e2-standard-4"
+         "GCP_PROJECT=proj" "GCP_ZONE=us-central1-a"
+         "GOOGLE_APPLICATION_CREDENTIALS=$SCRATCH/sa.json")
+: >"$SCRATCH/sa.json"
+write_repo_env "${GCP_ENV[@]}"
+
+# (a) Label absent -> existing-instance reuse proceeds unchanged.
+run_rr MOCK_GCP_STATE=TERMINATED MOCK_GCP_FLEET_LABEL= -- up --yes --json
+assert_eq   "GCP: no fleet label -> reuse succeeds" "0" "$RR_RC"
+assert_contains "GCP: reports reused" "$RR_OUT" '"reused":true'
+assert_contains "GCP: stopped instance started" "$(cat "$MOCK_LOG")" "instances start"
+
+# (b) Label present, no --force -> blocked before start/alias.
+write_repo_env "${GCP_ENV[@]}"
+run_rr MOCK_GCP_STATE=TERMINATED MOCK_GCP_FLEET_LABEL=loom -- up --yes --json
+assert_eq   "GCP: fleet-labeled instance is refused (exit 5)" "5" "$RR_RC"
+assert_contains "GCP: message names the marker label" "$RR_ERR" "Fleet=loom"
+assert_eq   "GCP: blocked run never started it" "0" "$(grep -c 'instances start' "$MOCK_LOG" 2>/dev/null)"
+
+# (c) Label present with --force -> proceeds.
+run_rr MOCK_GCP_STATE=TERMINATED MOCK_GCP_FLEET_LABEL=loom -- up --yes --force --json
+assert_eq   "GCP: --force lets it through" "0" "$RR_RC"
+assert_contains "GCP: --force warns loudly" "$RR_ERR" "WARNING"
+assert_contains "GCP: --force run started the instance" "$(cat "$MOCK_LOG")" "instances start"
+
+write_repo_env "REPO_REMOTE_INSTANCE_TYPE=m5.2xlarge"
+
+# ---------------------------------------------------------------------------
+echo ""
 echo "-- GPU detection + cost --"
 # ---------------------------------------------------------------------------
 write_repo_env "REPO_REMOTE_INSTANCE_TYPE=g6e.xlarge"
@@ -442,6 +569,14 @@ assert_contains "remote.md documents the default marker path" \
 assert_contains "remote.md documents the marker's mtime semantics" "$MD" "mtime"
 assert_contains "remote.md recommends a short idle window for daemon/worker hosts" \
   "$MD" "REPO_REMOTE_IDLE_SHUTDOWN_MIN=20"
+
+# repo#164: the fleet-marker reuse guard and its --force override are part of
+# the implemented surface, so remote.md must document them too.
+assert_contains "remote.md documents the --force override" "$MD" "--force"
+assert_contains "remote.md documents the fleet-marker key var" "$MD" "REPO_REMOTE_FLEET_TAG_KEY"
+assert_contains "remote.md documents the fleet-marker value var" "$MD" "REPO_REMOTE_FLEET_TAG_VALUE"
+assert_contains "remote.md documents the default fleet marker" "$MD" "Fleet=loom"
+assert_contains "remote.md documents the refusal exit code" "$MD" "exit \`5\`"
 
 # The interactive steps must DELEGATE to the shared script, not re-issue cloud
 # CLI calls from prose (the "no behavior drift" acceptance criterion).

--- a/scripts/repo/repo-remote.sh
+++ b/scripts/repo/repo-remote.sh
@@ -20,12 +20,15 @@
 # Subcommands (both the `up`/`down`/`status` verbs and the remote.md-style
 # `--status`/`--down` flags are accepted, for parity with the prose command):
 #
-#   repo-remote up [--yes] [--json] [aws|gcp]     Provision (or reuse) an instance.
+#   repo-remote up [--yes] [--force] [--json] [aws|gcp]   Provision (or reuse)
+#       an instance.
 #       Without --yes: a DRY-RUN plan (resolved spec + estimated cost) is emitted
 #       and NOTHING is created — this is the "plan shown before money spent" path.
 #       With --yes: the plan is executed. --yes removes the *prompt*, never the
 #       *consent requirement*: a cost-relevant field missing from config is a
 #       loud, non-zero-exit failure, never a silent default (repo#52 cost gate).
+#       --force overrides the fleet-marker guard described below. It does NOT
+#       relax the cost gate.
 #
 #   repo-remote status|--status [--json] [aws|gcp]   List instances this command
 #       created (tagged repo-remote=<name>) with state; no mutation.
@@ -46,11 +49,26 @@
 # not consent. Non-cost-relevant fields (disk, idle window, image) do fall back
 # to built-in defaults, matching the prose command.
 #
+# Fleet-marker guard (repo#164): `up` reuses an instance it *discovers* — a
+# pinned REPO_REMOTE_INSTANCE_ID, or one carrying the repo-remote=<name> tag/label.
+# That discovery is stale-tag-prone: a host provisioned once for an ephemeral dev
+# session can later become a persistent fleet worker while still carrying the
+# repo-remote tag, at which point this ephemeral tooling would happily start and
+# SSH-alias a production box (2AMLogic/2am#52). So before starting or aliasing a
+# REUSED instance, its tags (AWS) / labels (GCP) are checked for a fleet marker —
+# by default Fleet=loom, configurable via REPO_REMOTE_FLEET_TAG_KEY /
+# REPO_REMOTE_FLEET_TAG_VALUE. If present, the run STOPS (exit 5) with a clear
+# message unless --force is given; with --force it proceeds after a loud warning.
+# Setting REPO_REMOTE_FLEET_TAG_KEY= (empty) disables the check entirely. The
+# guard never applies to a freshly created instance (nothing to inherit) and
+# never to a dry run (which touches no cloud resource at all).
+#
 # Exit codes:
 #   0  success (including a dry-run plan)
 #   2  missing / invalid required config (the cost gate; loud failure)
 #   3  provider authentication failed
 #   4  cloud operation failed
+#   5  refused to reuse a fleet-marked instance (pass --force to override)
 #   64 usage error
 #
 # Testability hooks (honored so the suite can exercise the full contract against
@@ -69,6 +87,7 @@ die()  { local code="$1"; shift; printf '%s\n' "repo-remote: ERROR: $*" >&2; exi
 
 JSON_OUT=false   # --json
 YES=false        # --yes
+FORCE=false      # --force (override the fleet-marker guard)
 DELETE=false     # --down --delete
 ACTION=""        # up | down | status
 PROVIDER_ARG=""  # aws | gcp (positional override)
@@ -117,6 +136,8 @@ IMAGE=""
 GPU_ACCEL=""       # GCP accelerator string, e.g. nvidia-l4:1
 IDLE_MIN=""
 IS_GPU=false
+FLEET_TAG_KEY=""   # tag/label key that marks a managed fleet host ("" disables)
+FLEET_TAG_VALUE="" # required value for that key ("" = any non-empty value)
 REGION=""
 COST_HOURLY=""
 COST_APPROX=false
@@ -206,6 +227,12 @@ resolve_settings() {
   # works standalone — it stays inert until the file actually exists on-host.
   IDLE_MARKER="${REPO_REMOTE_IDLE_MARKER:-/var/run/repo-remote-daemon-idle.marker}"
 
+  # Fleet marker (repo#164). Defaults match the tag 2am's remediation already
+  # sets on its persistent workers, so the guard is useful with zero config.
+  # An empty key is the deliberate opt-out: no marker lookup is performed.
+  FLEET_TAG_KEY="${REPO_REMOTE_FLEET_TAG_KEY-Fleet}"
+  FLEET_TAG_VALUE="${REPO_REMOTE_FLEET_TAG_VALUE-loom}"
+
   case "$PROVIDER" in
     aws) REGION="${AWS_REGION:-${AWS_DEFAULT_REGION:-}}" ;;
     gcp) REGION="${GCP_ZONE:-}" ;;
@@ -252,6 +279,76 @@ require_cost_config() {
     log "set them in ${SHARED_ENV} (shared) or ${REPO_ENV:-<git-root>/.env} (per-repo), or run /repo:remote --configure."
     exit 2
   fi
+}
+
+# ── the fleet-marker guard (reuse discovery, repo#164) ──────────────────────
+# `up` never re-attaches user-data to an instance it reuses — the guard a host
+# carries is whatever it got at its one-time creation. What reuse DOES do is
+# start a stopped instance and rewrite this repo's SSH alias to point at it. The
+# instance it reaches is resolved from a pinned REPO_REMOTE_INSTANCE_ID or from
+# the repo-remote=<name> tag/label, and neither of those handles expires: a box
+# provisioned once as an ephemeral dev session can since have become a
+# persistent, daemon-managed fleet worker while still carrying the old tag. That
+# is exactly how `repo-remote=anvil` tooling kept rediscovering `loom-worker-1`
+# after it became a fleet host (2AMLogic/2am#52).
+#
+# So: before a REUSED instance is started or aliased, look for a fleet marker
+# the fleet-management side already had to set deliberately elsewhere. This is a
+# provisioning-time check against declared metadata — deliberately NOT an
+# on-host "is some process running" heuristic, which repo#79 rejected for the
+# guard's runtime logic and which nothing here reopens.
+
+# True when a discovered marker value counts as "this is a fleet host".
+# Compared case-insensitively: GCP lower-cases label values, AWS tags don't.
+# An empty REPO_REMOTE_FLEET_TAG_VALUE means "any non-empty value matches".
+fleet_marker_matches() {  # <discovered-value>
+  local got want
+  [[ -n "$1" && "$1" != "None" ]] || return 1
+  [[ -n "$FLEET_TAG_VALUE" ]] || return 0
+  got="$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')"
+  want="$(printf '%s' "$FLEET_TAG_VALUE" | tr '[:upper:]' '[:lower:]')"
+  [[ "$got" == "$want" ]]
+}
+
+# Warn-or-refuse once a marker has been read off a resource being reused.
+# Dies with exit 5 unless --force; with --force it warns loudly and continues.
+fleet_marker_gate() {  # <resource-id> <marker-value> <"tag"|"label">
+  local id="$1" val="$2" kind="$3"
+  fleet_marker_matches "$val" || return 0
+  if [[ "$FORCE" == true ]]; then
+    log "WARNING: ${id} carries the fleet marker ${kind} ${FLEET_TAG_KEY}=${val} — it looks like a managed fleet/daemon host, not an ephemeral dev box. Proceeding anyway because --force was given; this run will start and/or re-alias a production host."
+    return 0
+  fi
+  # Same "repo-remote: ERROR:" shape as die(), but die() is a single line and
+  # this refusal is only actionable with the remediation lines that follow it.
+  printf '%s\n' "repo-remote: ERROR: refusing to reuse ${id}: it carries the fleet marker ${kind} ${FLEET_TAG_KEY}=${val}." >&2
+  log "  That marker means the host is managed as part of a fleet (e.g. a persistent loom-daemon worker), so starting or re-aliasing it from ephemeral dev-session tooling is almost certainly not what you want (2AMLogic/2am#52)."
+  log "  If you really mean to target it, re-run with --force."
+  log "  To use a different box instead, clear REPO_REMOTE_INSTANCE_ID from ${REPO_ENV:-<git-root>/.env} (and/or remove the repo-remote=${NAME} tag from the fleet host)."
+  log "  To disable this check entirely, set REPO_REMOTE_FLEET_TAG_KEY= (empty)."
+  exit 5
+}
+
+# AWS: read the fleet tag off an instance. Echoes "" when absent/disabled.
+aws_fleet_marker() {  # <instance-id>
+  [[ -n "$FLEET_TAG_KEY" ]] || return 0
+  local v
+  v="$(aws ec2 describe-instances --instance-ids "$1" \
+      --query "Reservations[0].Instances[0].Tags[?Key=='${FLEET_TAG_KEY}'].Value | [0]" \
+      --output text 2>/dev/null)" || return 0
+  [[ "$v" == "None" ]] && v=""
+  printf '%s' "$v"
+}
+
+# GCP: read the fleet label off an instance. Label keys are lower-case on GCP,
+# so the configured key is lower-cased for the lookup. Echoes "" when absent.
+gcp_fleet_marker() {  # <instance-name>
+  [[ -n "$FLEET_TAG_KEY" ]] || return 0
+  local k v
+  k="$(printf '%s' "$FLEET_TAG_KEY" | tr '[:upper:]' '[:lower:]')"
+  v="$(gcloud compute instances describe "$1" --zone "$REGION" \
+      --format="value(labels.${k})" 2>/dev/null || true)"
+  printf '%s' "$v"
 }
 
 # ── the idle-shutdown guard (cloud-init user-data) ──────────────────────────
@@ -430,6 +527,12 @@ aws_up() {
 
   if [[ -n "$INSTANCE_ID" ]]; then
     state="$(aws_instance_state "$INSTANCE_ID")"
+    # Fleet-marker guard BEFORE any start/alias: a pinned id can outlive the
+    # host's role as an ephemeral dev box (repo#164). Skipped when the pin is
+    # already stale (missing) — there is nothing to protect.
+    if [[ "$state" != missing ]]; then
+      fleet_marker_gate "$INSTANCE_ID" "$(aws_fleet_marker "$INSTANCE_ID")" tag
+    fi
     case "$state" in
       running)          iid="$INSTANCE_ID"; reused=true ;;
       stopped|stopping) aws ec2 start-instances --instance-ids "$INSTANCE_ID" >/dev/null 2>&1 \
@@ -446,6 +549,9 @@ aws_up() {
     if [[ -n "$found" ]]; then
       iid="$(printf '%s' "$found" | awk '{print $1}')"
       state="$(printf '%s' "$found" | awk '{print $2}')"
+      # Same guard on the tag-discovery path — the repo-remote=<name> tag is
+      # exactly the stale handle that let dev tooling rediscover a fleet host.
+      fleet_marker_gate "$iid" "$(aws_fleet_marker "$iid")" tag
       reused=true
       if [[ "$state" == stopped || "$state" == stopping ]]; then
         aws ec2 start-instances --instance-ids "$iid" >/dev/null 2>&1 \
@@ -529,6 +635,9 @@ gcp_up() {
   state="$(gcloud compute instances describe "$vm" --zone "$REGION" \
     --format='value(status)' 2>/dev/null || true)"
   if [[ -n "$state" ]]; then
+    # Fleet-marker guard BEFORE any start/alias (repo#164) — the GCP analogue of
+    # the AWS reuse check, against instance labels instead of tags.
+    fleet_marker_gate "$vm" "$(gcp_fleet_marker "$vm")" label
     reused=true
     if [[ "$state" != "RUNNING" ]]; then
       gcloud compute instances start "$vm" --zone "$REGION" >/dev/null 2>&1 \
@@ -746,7 +855,10 @@ emit_down_result() {  # <ids> <disposition: noop|dry-run|stopped|terminated>
 
 # ── argument parsing ────────────────────────────────────────────────────────
 usage() {
-  sed -n '4,60p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+  # Print the whole leading comment block (from line 4 to the first non-comment
+  # line) rather than a hard-coded line range, so --help cannot silently start
+  # truncating the header when documentation is added to it.
+  awk 'NR >= 4 { if ($0 !~ /^#/) exit; sub(/^# ?/, ""); print }' "${BASH_SOURCE[0]}"
 }
 
 parse_args() {
@@ -756,6 +868,7 @@ parse_args() {
       --status)       ACTION="status" ;;
       --down)         ACTION="down" ;;
       --yes|-y)       YES=true ;;
+      --force)        FORCE=true ;;
       --json)         JSON_OUT=true ;;
       --delete)       DELETE=true ;;
       aws|gcp)        PROVIDER_ARG="$1" ;;


### PR DESCRIPTION
## Summary

Implements **Option B only** from #164 (the Curator's corrected scope and the Champion-approved direction); Option A (role-based idle-guard defaults) is explicitly deferred as a follow-up.

`repo-remote up` resolves an instance to *reuse* from handles that never expire — a pinned `REPO_REMOTE_INSTANCE_ID`, or the `repo-remote=<name>` tag/label — then starts it and rewrites this repo's SSH alias to point at it. A box provisioned once for an ephemeral dev session can since have been repurposed into a persistent, daemon-managed fleet worker while still carrying the old tag, so that discovery could silently start and re-alias a production host. That is the second finding of the 2AMLogic/2am#52 incident (`repo-remote=anvil` tooling kept rediscovering the host that had become `loom-worker-1`).

Per the Curator's correction, the gate is on **reuse discovery**, not on "guard reattachment" — this codebase never re-attaches user-data to a reused instance, so no such reattachment exists to gate.

## Changes

- **`scripts/repo/repo-remote.sh`**
  - New `fleet_marker_matches()` / `fleet_marker_gate()` plus provider readers `aws_fleet_marker()` (instance tags) and `gcp_fleet_marker()` (instance labels, key lower-cased for GCP).
  - Gate wired into all three reuse branches, **before** any `start-instances` / `instances start` / SSH-alias write: `aws_up()`'s pinned-`REPO_REMOTE_INSTANCE_ID` branch, `aws_up()`'s `aws_find_tagged()` branch, and `gcp_up()`'s existing-instance branch.
  - New `--force` flag. Without it, a match exits **5** with a message naming the instance, the marker found, and every remediation (clear the pin, remove the stale tag, `--force`, or disable the check). With it, a loud `WARNING` is emitted and the run proceeds.
  - Config: `REPO_REMOTE_FLEET_TAG_KEY` (default `Fleet`; **empty disables the check**) and `REPO_REMOTE_FLEET_TAG_VALUE` (default `loom`; empty = any non-empty value). Value comparison is case-insensitive since GCP lower-cases label values. Both use `${VAR-default}` so an explicit empty setting is honored rather than falling back.
  - `usage()` now scans the leading comment block with `awk` instead of a hard-coded `sed -n '4,60p'` range, so `--help` does not silently truncate now that the header documents the new guard.
- **`commands/repo/remote.md`** — new `#### Fleet-marked hosts: the reuse guard` subsection immediately after the idle-guard docs; `--force` and the exit-code table in the headless-usage block; the guard as step 3.3 of "Reuse or find the instance"; the two new env vars in the `.env` reference.
- **`commands/repo/tests/test-repo-remote.sh`** — mock `aws` now answers the `Tags[?Key=…]` projection; a new minimal mock `gcloud` covers `gcp_up()`; 30 new cases.

`--force` deliberately does **not** relax the cost gate — an `up --yes --force` with no `REPO_REMOTE_INSTANCE_TYPE` still fails with exit 2.

## Acceptance Criteria Verification

| Criterion (from #164) | Status | Verification |
|---|---|---|
| AWS reuse paths (pinned id + `aws_find_tagged`) check the resolved instance's tags for a configurable fleet marker before starting/aliasing | Yes | `fleet_marker_gate` calls added in both branches ahead of `start-instances` and `write_ssh_alias`; tests (b) and (d) assert `grep -c 'start-instances'` is `0` on a blocked run |
| GCP reuse path (`gcp_up`'s existing-instance branch) performs the equivalent check against labels | Yes | `gcp_fleet_marker` + gate before `instances start`; new mock `gcloud` drives the three GCP cases |
| Marker present ⇒ warns clearly and requires explicit `--force`, rather than silently starting/aliasing | Yes | Exit `5` with instance id, `Fleet=loom` and `--force` in the message; blocked run asserted to leave the SSH alias byte-identical |
| `commands/repo/remote.md` documents the check and the override flag | Yes | New subsection + usage/exit-code/env-var docs; 5 new doc-drift assertions pin them so script and prose can't diverge |
| Regression tests: marker absent (unchanged), present without `--force` (blocked, clear message), present with `--force` (proceeds) | Yes | Cases (a)/(b)/(c) for AWS pinned, (d) for tag discovery, and the three GCP cases; plus non-matching value, custom key/value, empty-key opt-out, and dry-run-never-blocked |

Out of the issue's explicit non-goals: no process-name sniffing was added anywhere, and the idle guard's `who`/load activity model is byte-for-byte unchanged.

## Test Plan

- `commands/repo/tests/test-repo-remote.sh` — **133 pass, 0 fail** (was 103; +30 new cases).
- Full suite `./hooks/repo/tests/run.sh` (= `pnpm test` / `pnpm check:ci`) — **PASS: 1612, FAIL: 0**.
- `bash -n scripts/repo/repo-remote.sh` clean; `shellcheck` output on both changed shell files is **identical to the `origin/main` baseline** (2×SC2015, 2×SC2016, 3×SC2059, 2×SC2094 — all pre-existing info-level findings in untouched code, no new lint).
- `repo-remote --help` verified to render the full header after the `usage()` change.

## Pre-existing Issues (Not Addressed)

The shellcheck info-level findings above pre-date this PR and live in code this change does not touch (`write_ssh_alias`, `parse_args`, and the test suite's `printf` colour formatting). Left alone to keep the diff scoped.

Closes #164