### PR TITLE
docs(repo): stop the README layout block drifting file-by-file

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,18 +156,18 @@ skills/repo/SKILL.md         Domain overview installed to .claude/skills/repo/
 commands/repo/*.md           Command files installed to .claude/commands/repo/
 scripts/repo/repo-remote.sh  Headless /repo:remote provisioning entry point, installed to .claude/skills/repo/scripts/
 scripts/repo/resync-installed.sh  Consumer-side resync (contract C7), installed to .claude/skills/repo/scripts/
+scripts/repo/repo-scrub-forks.sh  /repo:scrub fork-network sweep, installed to the same place
 hooks/repo/guard-destructive.sh  PreToolUse guard hook installed to .claude/skills/repo/hooks/
 hooks/repo/session-start-handoff.sh  SessionStart handoff-note hook installed to the same place
-hooks/repo/tests/run.sh      Smoke suite covering both hooks (bash, no framework needed)
-hooks/repo/tests/test-guard-destructive.sh  Full guard regression suite (ported from Loom)
-hooks/repo/tests/test-session-start-handoff.sh  Handoff-hook suite (run.sh delegates to it)
-hooks/repo/tests/test-install-claude-md-markers.sh  CLAUDE.md marker-block regression suite
-hooks/repo/tests/test-shell-wrapper.sh  claude + codex shell wrapper suite (run.sh delegates to it)
-commands/repo/tests/test-branches-loss-check.sh  branches.md permanent-loss check suite (run.sh delegates)
-commands/repo/tests/test-repo-remote.sh  repo-remote.sh provisioning-contract suite (run.sh delegates)
-commands/repo/tests/test-verify-fix-persistence.sh  verify-after-write contract suite (run.sh delegates)
-commands/repo/tests/test-resync-installed.sh  resync-installed.sh suite (run.sh delegates)
-commands/repo/tests/test-installer-contract.sh  INSTALLER-CONTRACT.md C1-C8 conformance (run.sh delegates)
+hooks/repo/tests/run.sh      Test entry point (bash, no framework needed): inline smoke cases
+                             plus every delegated suite below. `pnpm test` runs it
+hooks/repo/tests/test-*.sh   Hook suites — guard regression, handoff hook, CLAUDE.md
+                             markers, sidecar untracking, claude + codex shell wrappers
+commands/repo/tests/test-*.sh  Command-contract suites — branches loss check, repo-remote
+                             provisioning, verify-after-write, early sync-and-switch, tidy
+                             KEEP tiers, C7 resync, installer contract, fork-network sweep,
+                             scrub/all/prune contract, links precision, guard equivalence
+                             (its case table lives in guard-equivalence-cases.txt)
 INSTALLER-CONTRACT.md        Normative tool-package installer contract (C1-C8), owned by this repo
 install.sh                   Installer
 uninstall.sh                 Uninstaller


### PR DESCRIPTION
## Summary

A `/repo:all` sweep found the README's **Repository layout** block six suites
behind disk. It listed 10 of the 16 test suites `hooks/repo/tests/run.sh`
actually delegates to, and omitted `scripts/repo/repo-scrub-forks.sh` entirely.

`/repo:docs` step 2 checks "do file trees and directory listings match disk?",
so this block is meant to track reality — it just had no mechanism keeping it
there.

## Why globs rather than adding the six missing rows

Per-file enumeration is the defect, not the symptom. Every new suite needs a
matching README line, and the last four PRs to add one forgot it. Filling in
today's six rows buys accuracy until the next suite lands.

So the individual test rows become two globs — `hooks/repo/tests/test-*.sh` and
`commands/repo/tests/test-*.sh` — each annotated with what the group covers.
Adding a suite no longer requires a README edit to stay accurate.

The tradeoff is losing the one-line-per-suite descriptions. The group
annotations name all 16 (5 hook, 11 command), so coverage is still discoverable
from the README; what's gone is the file→description mapping. `run.sh` keeps its
own row as the entry point, now noting `pnpm test` runs it.

## Changes

- Add `scripts/repo/repo-scrub-forks.sh` alongside the other two installed scripts
- Replace 10 individual test rows with two annotated globs
- Note that `pnpm test` runs `run.sh`

## Test plan

- [x] `./hooks/repo/tests/run.sh` — 2138 pass, 0 fail (no behavior change; README-only)
- [x] Group annotations cross-checked against disk: 5 hook suites, 11 command
      suites, matching `ls` exactly
- [x] Every suite named in the annotations confirmed present in `run.sh`'s
      delegation list

## Notes for the reviewer

The glob-vs-explicit call is the judgment worth a second opinion. If you'd
rather keep per-file rows, the alternative is adding the six missing ones and
accepting that this recurs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)