### PR TITLE
chore(deps): scaffold Dependabot for github-actions and docker

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,29 @@
+version: 2
+
+# Scaffolded by /repo:deps. Ecosystems here are the ones actually present and
+# repo-owned: package.json is scripts-only (no dependency blocks, empty
+# pnpm-lock.yaml), so npm is deliberately absent — there is nothing for
+# Dependabot to update there.
+updates:
+  # Low risk individually; reviewing each bump separately is noise, so group
+  # everything including majors. As of scaffolding, checkout/setup-node/
+  # action-setup are all v4 and CI warns they target the deprecated Node 20 —
+  # the grouped major bump is what clears that annotation.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels: ["tier:maintenance"]
+    groups:
+      github-actions:
+        patterns: ["*"]
+        update-types: ["major", "minor", "patch"]
+
+  # Ungrouped on purpose: there is one base image, and an Ubuntu LTS major
+  # (24.04 -> 26.04) rebuilds the /repo:remote dev container. That deserves its
+  # own reviewable PR rather than being folded into a batch.
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels: ["tier:maintenance"]


### PR DESCRIPTION
Scaffolds `.github/dependabot.yml` via `/repo:deps`.

## What was detected

| Manifest | Ecosystem | Ownership |
|---|---|---|
| `.github/workflows/ci.yml` | github-actions | repo-owned — 3 actions |
| `Dockerfile` | docker | repo-owned — `FROM ubuntu:24.04` |
| `package.json` | npm | repo-owned but **dependency-free** — excluded |

The `install-metadata.json` sweep finds tool roots at `.loom/` and `.claude/skills/repo/`; no detected manifest falls under either, so nothing here is installer-owned.

npm is excluded on the dependency-free rule: `package.json` is `private: true` with scripts only and all four dependency blocks null, and `pnpm-lock.yaml` is empty (`importers: { .: {} }`).

## Grouping

Per-ecosystem, not uniform:

- **github-actions** — grouped including majors. Individually reviewing CI action bumps is noise.
- **docker** — ungrouped. One base image, and an Ubuntu LTS major (24.04 → 26.04) rebuilds the `/repo:remote` dev container, so it deserves its own reviewable PR.

## Label

`tier:maintenance` — no label in this repo carries an `Applied by: humans` reservation, and this is the unrestricted maintenance-tier one. **No `loom:` label** is applied: routing bot PRs into the Loom auto-merge pipeline is a policy decision for the repo owner, not a side effect of a hygiene command.

## Related, already applied outside this PR

The two repo-level flags are independent of this file and were enabled directly:

- `vulnerability-alerts`: 404 → 204 (enabled)
- `dependabot_security_updates`: disabled → **enabled**

## Note on what merging this does

Dependabot fires on config **merge to the default branch**, not on the stated `weekly` interval — expect the first PRs within minutes of merge, not next Monday.

The first `github-actions` PR should clear the deprecation annotation CI currently emits on every run:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@v4, actions/setup-node@v4, pnpm/action-setup@v4

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LRn4xFB9HZif1eYNncdoxe