### PR TITLE
remote: refer to the fleet-host incident generically (no private tracker number, no hostname)

### DIFF
--- a/commands/repo/remote.md
+++ b/commands/repo/remote.md
@@ -473,8 +473,8 @@ ephemeral dev session can since have been repurposed into a persistent,
 daemon-managed fleet worker while still carrying the old tag, at which point
 ephemeral dev-session tooling would silently start-and-re-alias it (`up`) or
 stop/terminate it (`down`) as if it were still just a throwaway dev box. That is
-the second finding of the 2AMLogic/2am#52 incident, where `repo-remote=anvil`
-tooling kept rediscovering the host that had become `loom-worker-1`; `down
+the second finding of an operator incident (private tracker), where `repo-remote=anvil`
+tooling kept rediscovering the host that had become a fleet host; `down
 --delete` against that same stale handle is the strictly worse outcome — the
 disk is gone, unrecoverable.
 

--- a/commands/repo/tests/test-repo-remote.sh
+++ b/commands/repo/tests/test-repo-remote.sh
@@ -708,7 +708,7 @@ echo "-- fleet-marker guard on AWS reuse discovery (repo#164) --"
 # Reuse discovery (a pinned REPO_REMOTE_INSTANCE_ID, or the repo-remote=<name>
 # tag) resolves a handle that can outlive the host's role as an ephemeral dev
 # box. Starting/re-aliasing a host that has since become a fleet worker is the
-# second finding of 2AMLogic/2am#52, so a fleet marker on the resolved instance
+# second finding of an operator incident (private tracker), so a fleet marker on the resolved instance
 # must block the run unless --force is passed.
 
 # (a) Marker ABSENT -> behavior is exactly as before (reuse proceeds).
@@ -910,7 +910,7 @@ echo "-- fleet-marker guard on AWS down (repo#170) --"
 # `down` resolves instances from the SAME never-expiring handles `up` does (a
 # pinned REPO_REMOTE_INSTANCE_ID, or the repo-remote=<name> tag), and is
 # strictly worse when it hits a repurposed fleet host: it STOPS it, or with
-# --delete TERMINATES it (disk gone, unrecoverable) — the 2AMLogic/2am#52
+# --delete TERMINATES it (disk gone, unrecoverable) — the operator incident (private tracker)
 # failure mode. Mirrors the up-side block above.
 
 # (a) Marker ABSENT -> unchanged behavior (stops as before).

--- a/scripts/repo/repo-remote.sh
+++ b/scripts/repo/repo-remote.sh
@@ -59,7 +59,7 @@
 # stale-tag-prone: a host provisioned once for an ephemeral dev session can
 # later become a persistent fleet worker while still carrying the repo-remote
 # tag, at which point this ephemeral tooling would happily reuse it
-# (2AMLogic/2am#52). `down` is the strictly worse case: it STOPS the resolved
+# (operator incident, private tracker). `down` is the strictly worse case: it STOPS the resolved
 # instance, or — with --delete — TERMINATES it, disk and all, unrecoverable.
 # So before `up` starts/aliases a REUSED instance, or `down` stops/terminates
 # any resolved instance, its tags (AWS) / labels (GCP) are checked for a fleet
@@ -374,8 +374,8 @@ require_cost_config() {
 # the repo-remote=<name> tag/label, and neither of those handles expires: a box
 # provisioned once as an ephemeral dev session can since have become a
 # persistent, daemon-managed fleet worker while still carrying the old tag. That
-# is exactly how `repo-remote=anvil` tooling kept rediscovering `loom-worker-1`
-# after it became a fleet host (2AMLogic/2am#52).
+# is exactly how `repo-remote=anvil` tooling kept rediscovering a fleet host
+# after it became a fleet host (operator incident, private tracker).
 #
 # So: before a REUSED instance is started or aliased, look for a fleet marker
 # the fleet-management side already had to set deliberately elsewhere. This is a
@@ -407,7 +407,7 @@ fleet_marker_gate() {  # <resource-id> <marker-value> <"tag"|"label">
   # Same "repo-remote: ERROR:" shape as die(), but die() is a single line and
   # this refusal is only actionable with the remediation lines that follow it.
   printf '%s\n' "repo-remote: ERROR: refusing to reuse ${id}: it carries the fleet marker ${kind} ${FLEET_TAG_KEY}=${val}." >&2
-  log "  That marker means the host is managed as part of a fleet (e.g. a persistent loom-daemon worker), so starting or re-aliasing it from ephemeral dev-session tooling is almost certainly not what you want (2AMLogic/2am#52)."
+  log "  That marker means the host is managed as part of a fleet (e.g. a persistent loom-daemon worker), so starting or re-aliasing it from ephemeral dev-session tooling is almost certainly not what you want (operator incident, private tracker)."
   log "  If you really mean to target it, re-run with --force."
   log "  To use a different box instead, clear REPO_REMOTE_INSTANCE_ID from ${REPO_ENV:-<git-root>/.env} (and/or remove the repo-remote=${NAME} tag from the fleet host)."
   log "  To disable this check entirely, set REPO_REMOTE_FLEET_TAG_KEY= (empty)."


### PR DESCRIPTION
`commands/repo/remote.md`, `scripts/repo/repo-remote.sh` and `commands/repo/tests/test-repo-remote.sh` explained the repurposed-fleet-host guard (#169/#171) by citing a private repository's issue number and a fleet worker's hostname. The rationale stands without either; both were public here and in every consumer's installed `.claude/skills/repo` copy. Surfaced by a 2026-08-21 disclosure read-audit. Wording only — no behavior change; tests still reference the same guard by its own issue numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)